### PR TITLE
Add PDF build for documentation

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -109,11 +109,24 @@ jobs:
           touch doc/build/html/.nojekyll
           echo "dev.acp.docs.pyansys.com" >> doc/build/html/CNAME
 
+      - name: Build PDF Documentation
+        run: |
+          sudo apt update
+          sudo apt-get install -y texlive-latex-extra latexmk fonts-freefont-otf
+          poetry run make -C doc latexpdf
+
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v2
         with:
           name: Documentation-html
           path: doc/build/html
+          retention-days: 7
+
+      - name: Upload PDF Documentation
+        uses: actions/upload-artifact@v2
+        with:
+          name: Documentation-pdf
+          path: doc/build/latex/*.pdf
           retention-days: 7
 
       - name: Deploy Documentation

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -28,6 +28,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.imgconverter",
     "sphinx.ext.autodoc.typehints",
     "sphinx.ext.napoleon",
     "numpydoc",


### PR DESCRIPTION
Adds back the PDF build for the documentation, using the
'imgconverter' Sphinx extension to make SVG images work.