### PR TITLE
Add option to run with custom API branch

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      api_branch:
+        description: 'Branch of the ansys-api-acp-private repository used during the build.'
+        required: false
 
 jobs:
   style:
@@ -29,6 +33,11 @@ jobs:
           git config --global url."https://${{ secrets.PYANSYS_CI_BOT_TOKEN }}@github.com/ansys/ansys-api-acp-private".insteadOf "https://github.com/ansys/ansys-api-acp-private"
           pip install poetry
           poetry install -E pre-commit
+
+      - name: Install custom API branch if needed
+        if: "${{ github.event.inputs.api_branch != '' }}"
+        run: |
+          poetry run pip install --force-reinstall git+https://github.com/ansys/ansys-api-acp-private.git@${{ github.event.inputs.api_branch }}
 
       - name: Run pre-commit
         run: |
@@ -62,6 +71,11 @@ jobs:
 
       - name: Install library, with test extra
         run: pip install $(echo dist/*.whl)[test]
+
+      - name: Install custom API branch if needed
+        if: "${{ github.event.inputs.api_branch != '' }}"
+        run: |
+          pip install --force-reinstall git+https://github.com/ansys/ansys-api-acp-private.git@${{ github.event.inputs.api_branch }}
 
       - name: Login in Github Container registry
         uses: docker/login-action@v1
@@ -101,6 +115,11 @@ jobs:
           git config --global url."https://${{ secrets.PYANSYS_CI_BOT_TOKEN }}@github.com/ansys/ansys-api-acp-private".insteadOf "https://github.com/ansys/ansys-api-acp-private"
           pip install poetry
           poetry install -E docs
+
+      - name: Install custom API branch if needed
+        if: "${{ github.event.inputs.api_branch != '' }}"
+        run: |
+          poetry run pip install --force-reinstall git+https://github.com/ansys/ansys-api-acp-private.git@${{ github.event.inputs.api_branch }}
 
       - name: Build HTML
         run: |


### PR DESCRIPTION
Fixes #43 

Add the option to run with a custom branch of the API repository
when manually launching the CI actions.

We use `pip --force-reinstall` to install the API package after the 
PyACP package and its dependencies are installed.