### PR TITLE
Add '--keep-going' flag to doc build

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Build HTML
         run: |
-          poetry run make -C doc html SPHINXOPTS="-W"
+          poetry run make -C doc html SPHINXOPTS="-W --keep-going"
           touch doc/build/html/.nojekyll
           echo "dev.acp.docs.pyansys.com" >> doc/build/html/CNAME
 


### PR DESCRIPTION
Fixes #38.

Still treats warnings as errors, but keeps the build running. In this way, we can see all the warnings before the error is raised.