### PR TITLE
Implement '.pop' and '.popitem' for collection

### DIFF
--- a/examples/test.ipynb
+++ b/examples/test.ipynb
@@ -100,6 +100,42 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "mg_new = model.modeling_groups.pop(\"New Modeling Group 23\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(model.modeling_groups)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mg_new.store(parent=model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(model.modeling_groups)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "del model.modeling_groups[\"New Modeling Group 23\"]"
    ]
   },

--- a/src/ansys/acp/core/_grpc_helpers/collection.py
+++ b/src/ansys/acp/core/_grpc_helpers/collection.py
@@ -36,7 +36,7 @@ class Collection(Generic[ValueT]):
         channel: Channel,
         collection_path: CollectionPath,
         stub: ResourceStub,
-        object_constructor: Callable[[ObjectInfo, Channel], ValueT],
+        object_constructor: Callable[[ObjectInfo, Optional[Channel]], ValueT],
     ) -> None:
         self._collection_path = collection_path
         self._stub = stub
@@ -86,11 +86,19 @@ class Collection(Generic[ValueT]):
                 )
             )
 
-    # def pop(self, key):
-    #     raise NotImplementedError()
+    def pop(self, key: str) -> ValueT:
+        obj_info = self._get_objectinfo_by_id(key)
+        return self._pop_from_info(obj_info)
 
-    # def popitem(self, key):
-    #     raise NotImplementedError()
+    def popitem(self) -> ValueT:
+        obj_info = self._get_objectinfo_list()[0]
+        return self._pop_from_info(obj_info)
+
+    def _pop_from_info(self, object_info: ObjectInfo) -> ValueT:
+        obj = self._object_constructor(object_info, self._channel)
+        new_obj = obj.clone()
+        obj.delete()
+        return new_obj
 
     def values(self) -> Iterator[ValueT]:
         return (


### PR DESCRIPTION
Fixes #42.

Implement methods `.pop` and `.popitem` on the collection to remove an object from the server (keeping only a local representation). 
Also add `.clone()` and `.delete()` on the objects itself.

Compared to the `collections.abc.MutableMapping` interface, the `__setitem__`, `update` and `setdefault` methods are still missing. However, I think it is fine to close #42 for now, since it's not yet clear if we need `__setitem__` or how it should work if we do.