### PR TITLE
Add timeout to all Github action jobs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -22,6 +22,7 @@ jobs:
   style:
     name: Pre-commit Check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3
@@ -57,6 +58,7 @@ jobs:
   build:
     name: Build packages
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
 
@@ -94,6 +96,7 @@ jobs:
   testing:
     name: Testing
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: ['3.7', '3.10']
@@ -145,6 +148,7 @@ jobs:
   docs:
     name: Build Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Prevent actions from hanging indefinitely, like https://github.com/pyansys/pyacp-private/actions/runs/2532177560

The longest runs currently take ~<10 minutes (when grpc needs to be built), so a timeout of 30 minutes should leave plenty to spare.