### PR TITLE
Use __slots__ in tree objects

### DIFF
--- a/src/ansys/acp/core/_tree_objects/base.py
+++ b/src/ansys/acp/core/_tree_objects/base.py
@@ -5,7 +5,7 @@ via gRPC Put / Get calls.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Type, TypeVar, cast
+from typing import Any, Iterable, Optional, Type, TypeVar, cast
 
 from grpc import Channel
 
@@ -22,6 +22,8 @@ class TreeObject(ABC):
     """
     Base class for ACP tree objects.
     """
+
+    __slots__ = ("_channel_store", "_stub_store", "_pb_object")
 
     COLLECTION_LABEL: str
     OBJECT_INFO_TYPE: Type[ObjectInfo]
@@ -101,6 +103,7 @@ class TreeObject(ABC):
 
 
 class CreatableTreeObject(TreeObject, ABC):
+    __slots__: Iterable[str] = tuple()
     CREATE_REQUEST_TYPE: Type[CreateRequest]
 
     def _get_stub(self) -> CreatableResourceStub:

--- a/src/ansys/acp/core/_tree_objects/element_set.py
+++ b/src/ansys/acp/core/_tree_objects/element_set.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Container
+from typing import Container, Iterable
 
 from ansys.api.acp.v0 import element_set_pb2, element_set_pb2_grpc
 
@@ -14,6 +14,7 @@ __all__ = ["ElementSet"]
 
 @register
 class ElementSet(CreatableTreeObject):
+    __slots__: Iterable[str] = tuple()
     COLLECTION_LABEL = "element_sets"
     OBJECT_INFO_TYPE = element_set_pb2.ObjectInfo
     CREATE_REQUEST_TYPE = element_set_pb2.CreateRequest

--- a/src/ansys/acp/core/_tree_objects/fabric.py
+++ b/src/ansys/acp/core/_tree_objects/fabric.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union
+from typing import Iterable, Union
 
 from ansys.api.acp.v0 import fabric_pb2, fabric_pb2_grpc
 
@@ -54,6 +54,8 @@ class Fabric(CreatableTreeObject):
         Set the draping coefficient of the uni-directional draping model. Must be in the range of 0 to 1.
 
     """
+
+    __slots__: Iterable[str] = tuple()
 
     COLLECTION_LABEL = "fabrics"
     OBJECT_INFO_TYPE = fabric_pb2.ObjectInfo

--- a/src/ansys/acp/core/_tree_objects/material.py
+++ b/src/ansys/acp/core/_tree_objects/material.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Iterable
+
 from ansys.api.acp.v0 import material_pb2, material_pb2_grpc
 
 from .._grpc_helpers.property_helper import grpc_data_property_read_only
@@ -19,6 +21,8 @@ class Material(CreatableTreeObject):
     name :
         Name of the Material.
     """
+
+    __slots__: Iterable[str] = tuple()
 
     COLLECTION_LABEL = "materials"
     OBJECT_INFO_TYPE = material_pb2.ObjectInfo

--- a/src/ansys/acp/core/_tree_objects/model.py
+++ b/src/ansys/acp/core/_tree_objects/model.py
@@ -54,6 +54,8 @@ class Model(TreeObject):
         The ACP server on which the model resides.
     """
 
+    __slots__: Iterable[str] = tuple()
+
     COLLECTION_LABEL = "models"
     OBJECT_INFO_TYPE = model_pb2.ObjectInfo
 

--- a/src/ansys/acp/core/_tree_objects/modeling_group.py
+++ b/src/ansys/acp/core/_tree_objects/modeling_group.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterable
 
 from ansys.acp.core._grpc_helpers.property_helper import grpc_data_property_read_only
 from ansys.acp.core._tree_objects.modeling_ply import ModelingPly
@@ -15,6 +15,8 @@ __all__ = ["ModelingGroup"]
 
 @register
 class ModelingGroup(CreatableTreeObject):
+    __slots__: Iterable[str] = tuple()
+
     COLLECTION_LABEL = "modeling_groups"
     OBJECT_INFO_TYPE = modeling_group_pb2.ObjectInfo
     CREATE_REQUEST_TYPE = modeling_group_pb2.CreateRequest

--- a/src/ansys/acp/core/_tree_objects/modeling_ply.py
+++ b/src/ansys/acp/core/_tree_objects/modeling_ply.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Container, Union
+from typing import Container, Iterable, Union
 
 from ansys.api.acp.v0 import modeling_ply_pb2, modeling_ply_pb2_grpc
 
@@ -28,6 +28,8 @@ class ModelingPly(CreatableTreeObject):
     name :
         The name of the ModelingPly
     """
+
+    __slots__: Iterable[str] = tuple()
 
     COLLECTION_LABEL = "modeling_plies"
     OBJECT_INFO_TYPE = modeling_ply_pb2.ObjectInfo

--- a/src/ansys/acp/core/_tree_objects/oriented_selection_set.py
+++ b/src/ansys/acp/core/_tree_objects/oriented_selection_set.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence, Tuple
+from typing import Iterable, Sequence, Tuple
 
 from ansys.api.acp.v0 import oriented_selection_set_pb2, oriented_selection_set_pb2_grpc
 
@@ -40,6 +40,8 @@ class OrientedSelectionSet(CreatableTreeObject):
     rosette_selection_method :
         Selection Method for Rosettes of the Oriented Selection Set.
     """
+
+    __slots__: Iterable[str] = tuple()
 
     COLLECTION_LABEL = "oriented_selection_sets"
     OBJECT_INFO_TYPE = oriented_selection_set_pb2.ObjectInfo

--- a/src/ansys/acp/core/_tree_objects/rosette.py
+++ b/src/ansys/acp/core/_tree_objects/rosette.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Iterable, Tuple
 
 from ansys.api.acp.v0 import rosette_pb2, rosette_pb2_grpc
 
@@ -28,6 +28,8 @@ class Rosette(CreatableTreeObject):
     dir2 :
         Direction 2 (y-direction) vector of the Rosette.
     """
+
+    __slots__: Iterable[str] = tuple()
 
     COLLECTION_LABEL = "rosettes"
     OBJECT_INFO_TYPE = rosette_pb2.ObjectInfo


### PR DESCRIPTION
Using `__slots__` in the entire MRO of a class means that no dynamic
properties can be assigned. This guards against the error of not
defining the grpc property, but setting the attribute (directly on
the Python object's `__dict__`) in `__init__`.