### PR TITLE
Add action for nightly GHCR prune

### DIFF
--- a/.github/workflows/prune_containers.yml
+++ b/.github/workflows/prune_containers.yml
@@ -1,0 +1,21 @@
+name: Nightly prune of untagged containers
+
+on:
+  schedule:
+    - cron: '30 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  main:
+    name: Prune untagged GHCR images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: vlaurin/action-ghcr-prune@3c4f76ff904f206ace31dab45f37eb7c5a8e3d37
+        with:
+          organization: pyansys
+          token: ${{ secrets.PYANSYS_CI_BOT_PACKAGE_TOKEN }}
+          container: pyacp-private
+          dry-run: false # Dry-run first, then change to `false`
+          older-than: 14 # days
+          untagged: true


### PR DESCRIPTION
Add a nightly action to prune container packages without a tag which are older than 14 days. Based on 'vlaurin/action-ghcr-prune'.