### PR TITLE
Update to black 2023 format, add blacken-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,15 @@ repos:
   - id: pyupgrade
     args: [--py38-plus]
 - repo: https://github.com/psf/black
-  rev: '22.12.0'
+  rev: '23.1.0'
   hooks:
   - id: black
+- repo: https://github.com/adamchainz/blacken-docs
+  rev: 1.13.0
+  hooks:
+  - id: blacken-docs
+    additional_dependencies: [black==23.1.0]
+
 - repo: https://github.com/pycqa/isort
   rev: '5.12.0'
   hooks:

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Installation
 
 Install PyACP with:
 
-.. code::
+.. code-block::
 
     pip install git+https://github.com/pyansys/pyacp-private
 
@@ -70,7 +70,7 @@ Launching ACP
 
 Configure ACP using the `ansys-launcher <https://local-product-launcher.tools.docs.pyansys.com>`_ command line tool:
 
-.. code:: bash
+.. code-block:: bash
 
     ansys-launcher configure ACP <launch_mode>
 
@@ -84,7 +84,7 @@ The ``ansys-launcher`` prompts for the relevant options for each mode.
 
 Having configured the launcher, the server can be started with ``launch_acp``:
 
-.. code:: python
+.. code-block:: python
 
     import ansys.acp.core as pyacp
 
@@ -98,7 +98,7 @@ Basic Usage
 Once the server is running, we can start working with PyACP. For example, to load an ACP
 Model from an existing file:
 
-.. code:: python
+.. code-block:: pycon
 
     >>> remote_filename = client.upload_file(local_path="<MODEL_PATH>")
     >>> model = client.import_model(path=remote_filename)
@@ -116,33 +116,33 @@ please refer to the `PyAnsys Developer's guide`_.
 
 You will need to follow these steps:
 
-1. Start by cloning this repository, and entering the newly created directory:
+1.  Start by cloning this repository, and entering the newly created directory:
 
-    .. code:: bash
+    .. code-block:: bash
 
         git clone https://github.com/pyansys/pyacp-private
         cd pyacp-private
 
-2. Make sure you have the latest version of poetry:
+2.  Make sure you have the latest version of poetry:
 
-    .. code:: bash
+    .. code-block:: bash
 
         python -m pip install pipx
         pipx ensurepath
         pipx install poetry
 
-3. Install the project and all its development dependencies using poetry. This also takes care of
-   creating a new virtual environment:
+3.  Install the project and all its development dependencies using poetry. This also takes care of
+    creating a new virtual environment:
 
-    .. code:: bash
+    .. code-block:: bash
 
         poetry install --with dev,test
 
    This step installs pyACP in an editable mode (no build step is needed, no re-install when changing the code).
 
-4. Activate your development virtual environment with:
+4.  Activate your development virtual environment with:
 
-    .. code:: bash
+    .. code-block:: bash
 
         poetry shell
 
@@ -150,7 +150,7 @@ You will need to follow these steps:
 
 .. 6. Verify your development installation by running:
 
-..     .. code:: bash
+..     .. code-block:: bash
 
 ..         tox
 
@@ -161,7 +161,7 @@ Testing
 
 The PyACP test suite uses `pytest`_. You can run it with
 
-.. code:: bash
+.. code-block:: bash
 
     pytest --license-server=<YOUR_LICENSE_SERVER>
 
@@ -170,13 +170,13 @@ Pre-commit hooks
 
 Style and linter checks are run through the `pre-commit`_ tool. You can run these checks with
 
-.. code:: bash
+.. code-block:: bash
 
     pre-commit run --all-files
 
 We also recommend installing pre-commit into your repository:
 
-.. code:: bash
+.. code-block:: bash
 
     pre-commit install
 
@@ -188,7 +188,7 @@ Documentation
 
 To build the documentation, a PyACP server needs to be running:
 
-.. code:: bash
+.. code-block:: bash
 
     docker-compose -f docker-compose/docker-compose.yaml up -d
 
@@ -196,13 +196,13 @@ It can then be built using `Sphinx`_.
 
 On Linux & MacOS:
 
-.. code:: sh
+.. code-block:: sh
 
     make -C doc html
 
 On Windows:
 
-.. code:: batch
+.. code-block:: batch
 
     cd doc; .\make.bat html
 
@@ -213,14 +213,14 @@ Distribution
 
 The following commands can be used to build and check the PyACP package:
 
-.. code:: bash
+.. code-block:: bash
 
     poetry build
     twine check dist/*
 
 This creates both a source distribution, and a wheel file. An alternative is
 
-.. code:: bash
+.. code-block:: bash
 
     pip install build
     python -m build --wheel

--- a/doc/source/examples/others/local_pyacp_executable.rst
+++ b/doc/source/examples/others/local_pyacp_executable.rst
@@ -42,7 +42,13 @@ and ansys-mapdl) are installed before launching Python.
 
     # Launch gRPC server and pyACP client
     import ansys.acp.core as pyacp
-    pyacp_server = pyacp.launch_acp(binary_path=acp_grpc_exe, port=50555, stdout_file="pyacp.log", stderr_file="pyacp.err")
+
+    pyacp_server = pyacp.launch_acp(
+        binary_path=acp_grpc_exe,
+        port=50555,
+        stdout_file="pyacp.log",
+        stderr_file="pyacp.err",
+    )
     pyacp.wait_for_server(pyacp_server, timeout=30)  # ensure the server is running
     pyacp_client = pyacp.Client(pyacp_server)
 
@@ -53,9 +59,8 @@ and ansys-mapdl) are installed before launching Python.
     # Import the model from MAPDL input file (CDB)
     # Note: the unit system is required for the post-processing
     CDB_FILENAME = "class40.cdb"
-    model = pyacp_client.import_model(path=CDB_FILENAME,
-        format="ansys:cdb",
-        unit_system=pyacp.UnitSystemType.MPA
+    model = pyacp_client.import_model(
+        path=CDB_FILENAME, format="ansys:cdb", unit_system=pyacp.UnitSystemType.MPA
     )
     model
 
@@ -80,13 +85,18 @@ and ansys-mapdl) are installed before launching Python.
     corecell_103kg_10mm = model.create_fabric(
         name="Corecell 103kg", thickness=0.01, material=mat_corecell_103kg
     )
-    eglass_ud_02mm = model.create_fabric(name="eglass UD", thickness=0.0002, material=mat_eglass_ud)
+    eglass_ud_02mm = model.create_fabric(
+        name="eglass UD", thickness=0.0002, material=mat_eglass_ud
+    )
 
     # Specify rosettes (coordinate systems)
     ros_deck = model.create_rosette(name="ros_deck", origin=(-5.9334, -0.0481, 1.693))
     ros_hull = model.create_rosette(name="ros_hull", origin=(-5.3711, -0.0506, -0.2551))
     ros_bulkhead = model.create_rosette(
-        name="ros_bulkhead", origin=(-5.622, 0.0022, 0.0847), dir1=(0.0, 1.0, 0.0), dir2=(0.0, 0.0, 1.0)
+        name="ros_bulkhead",
+        origin=(-5.622, 0.0022, 0.0847),
+        dir1=(0.0, 1.0, 0.0),
+        dir2=(0.0, 0.0, 1.0),
     )
     ros_keeltower = model.create_rosette(
         name="ros_keeltower", origin=(-6.0699, -0.0502, 0.623), dir1=(0.0, 0.0, 1.0)
@@ -132,6 +142,7 @@ and ansys-mapdl) are installed before launching Python.
         rosettes=[ros_keeltower],
     )
 
+
     # Add plies to all parts
     def add_ply(mg, name, ply_material, angle, oss):
         return mg.create_modeling_ply(
@@ -142,6 +153,7 @@ and ansys-mapdl) are installed before launching Python.
             number_of_layers=1,
             global_ply_nr=0,  # add at the end
         )
+
 
     angles = [-90.0, -60.0, -45.0 - 30.0, 0.0, 0.0, 30.0, 45.0, 60.0, 90.0]
     for mg_name in ["hull", "deck", "bulkhead"]:
@@ -188,6 +200,7 @@ and ansys-mapdl) are installed before launching Python.
 
     # Launch MAPDL
     from ansys.mapdl.core import launch_mapdl
+
     mapdl = launch_mapdl()
     # Load the CDB file with the composite lay-up
     mapdl.input(CDB_FILENAME_OUT)
@@ -217,7 +230,7 @@ and ansys-mapdl) are installed before launching Python.
         CombinedFailureCriterion,
         MaxStrainCriterion,
         MaxStressCriterion,
-        CoreFailureCriterion
+        CoreFailureCriterion,
     )
     from ansys.dpf.composites.result_definition import ResultDefinition
     from ansys.dpf.composites.server_helpers import load_composites_plugin
@@ -227,7 +240,13 @@ and ansys-mapdl) are installed before launching Python.
     dpf_server = dpf.start_local_server(ansys_path=os.environ[AWP_ROOT_KEY])
     base = dpf.BaseService(server=dpf_server, load_operators=False)
     base.load_library("Ans.Dpf.EngineeringData.dll", "EngineeringData")
-    composites_plugin_path = os.path.join(os.environ[AWP_ROOT_KEY], "dpf", "plugins", "dpf_composites", "composite_operators.dll")
+    composites_plugin_path = os.path.join(
+        os.environ[AWP_ROOT_KEY],
+        "dpf",
+        "plugins",
+        "dpf_composites",
+        "composite_operators.dll",
+    )
     base.load_library(composites_plugin_path, "Composites")
 
     # Configure failure criteria
@@ -237,7 +256,7 @@ and ansys-mapdl) are installed before launching Python.
 
     cfc = CombinedFailureCriterion(
         name="Combined Failure Criterion",
-        failure_criteria=[max_strain, max_stress, core_failure]
+        failure_criteria=[max_strain, max_stress, core_failure],
     )
 
     rstfile_path = os.path.join(mapdl.directory, f"{mapdl.jobname}.rst")
@@ -252,8 +271,8 @@ and ansys-mapdl) are installed before launching Python.
 
     # Configure and run DPF failure operator
     fc_op = dpf.Operator("composite::composite_failure_operator")
-    elements = list([int(v) for v in np.arange(1,3996)])
-    rd.element_scope=elements
+    elements = list([int(v) for v in np.arange(1, 3996)])
+    rd.element_scope = elements
     fc_op.inputs.result_definition(rd.to_json())
     output_all_elements = fc_op.outputs.fields_containerMax()
 

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,5 +1,5 @@
 These examples assume that MAPDL and DPF servers are already running. You can start them by running the following command from the root of the PyACP repository:
 
-.. code::
+.. code-block::
 
     docker-compose -f docker-compose/docker-compose-extras.yaml up -d

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ DOCKER_IMAGENAME_OPTION_KEY = "--docker-image"
 NO_SERVER_LOGS_OPTION_KEY = "--no-server-log-files"
 SERVER_STARTUP_TIMEOUT = 30.0
 
+
 # Add pytest command-line options
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Add command-line options to pytest."""

--- a/tests/test_fabric.py
+++ b/tests/test_fabric.py
@@ -32,7 +32,6 @@ def test_create_fabric(load_model_from_tempfile):
 def test_fabric_properties(load_model_from_tempfile):
     """Test the put request."""
     with load_model_from_tempfile() as model:
-
         fabric = model.create_fabric(name="test_properties")
         properties = {
             "name": "new_name",

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -17,7 +17,6 @@ def test_create_material(load_model_from_tempfile):
 def test_material_properties(load_model_from_tempfile):
     """Test the put request of a Material."""
     with load_model_from_tempfile() as model:
-
         material = model.create_material(name="test_properties")
         properties = {
             "name": "new_name",

--- a/tests/test_oriented_selection_set.py
+++ b/tests/test_oriented_selection_set.py
@@ -25,7 +25,6 @@ def test_create_oriented_selection_set(load_model_from_tempfile):
 def test_oriented_selection_set_properties(load_model_from_tempfile):
     """Test the put request of a Rosette."""
     with load_model_from_tempfile() as model:
-
         element_sets = [model.create_element_set() for _ in range(3)]
         rosettes = [model.create_rosette() for _ in range(4)]
 

--- a/tests/test_rosette.py
+++ b/tests/test_rosette.py
@@ -22,7 +22,6 @@ def test_create_rosette(load_model_from_tempfile):
 def test_rosette_properties(load_model_from_tempfile):
     """Test the put request of a Rosette."""
     with load_model_from_tempfile() as model:
-
         rosette = model.create_rosette(name="test_properties")
         properties = {
             "name": "new_name",


### PR DESCRIPTION
The `black` formatter updates its default style on a yearly cycle, see
https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy.

This PR updates to the 2023 style, and adds `blacken-docs` for formatting 
within the documentation.

Use the `code-block` instead of `code` for code blocks in `README.rst`; according to
the Sphinx docs, `code` is meant for in-line code (as opposed to blocks).