### PR TITLE
Disable force-orphan option in dev doc deployment

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -279,6 +279,7 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          force-orphan: false
 
   # Release:
   #   if: contains(github.ref, 'refs/tags')


### PR DESCRIPTION
Closes #153.

The `force-orphan: true` setting clashes with our branch policy to have linear history in `gh-pages`. See https://github.com/pyansys/actions/issues/206