### PR TITLE
Improve dependency specification

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -39,13 +39,13 @@ develop = false
 
 [package.dependencies]
 grpcio = ">=1.17,<2.0"
-protobuf = ">=3.19,<4.0"
+protobuf = ">=3.19,<5"
 
 [package.source]
 type = "git"
 url = "https://github.com/ansys-internal/ansys-api-acp.git"
 reference = "main"
-resolved_reference = "65953000c04bc6ed0b73926e740b1293dad393ae"
+resolved_reference = "c3f79fa9a2d890e4121d8952c91cc35a3e8fd4d4"
 
 [[package]]
 name = "ansys-api-mapdl"
@@ -213,14 +213,14 @@ grpcio = "*"
 
 [[package]]
 name = "ansys-mapdl-core"
-version = "0.62.3"
-description = "A Python wrapper for Ansys mapdl core"
+version = "0.64.1"
+description = "A Python wrapper for Ansys MAPDL."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ansys-mapdl-core-0.62.3.tar.gz", hash = "sha256:8120a34608f18ab5f8bd7ab252f2e8cbfded383461fc4a18022b6ac25d778193"},
-    {file = "ansys_mapdl_core-0.62.3-py3-none-any.whl", hash = "sha256:c2c464b5f5b15c54bc24932e7b36089659dbd3ea041ec2e67ddd16b0f8d8fb0c"},
+    {file = "ansys-mapdl-core-0.64.1.tar.gz", hash = "sha256:8e5f745680065527b5630ecc42a6894ba9a7085df6671a5e21b7a9554ed5e795"},
+    {file = "ansys_mapdl_core-0.64.1-py3-none-any.whl", hash = "sha256:80dec5614e4fdd4520839d2cb5e272e80182c17dd1e19e09b465a3cf262acbf3"},
 ]
 
 [package.dependencies]
@@ -229,16 +229,23 @@ ansys-corba = {version = "*", markers = "python_version < \"3.9\""}
 ansys-mapdl-reader = ">=0.51.7"
 ansys-platform-instancemanagement = ">=1.0,<2.0"
 appdirs = ">=1.4.0"
+click = ">=8.1.3"
 grpcio = ">=1.30.0"
 importlib-metadata = ">=4.0"
 matplotlib = ">=3.0.0"
 numpy = ">=1.14.0"
 pexpect = {version = ">=4.8.0", markers = "platform_system == \"Linux\""}
 protobuf = ">=3.12.2"
+psutil = ">=5.9.4"
+pyansys-tools-versioning = ">=0.3.3"
 pyiges = ">=0.1.4"
 pyvista = ">=0.33.0"
 scipy = ">=1.3.0"
 tqdm = ">=4.45.0"
+
+[package.extras]
+doc = ["ansys-dpf-core (==0.8.0)", "ansys-mapdl-reader (==0.52.11)", "ansys-sphinx-theme (==0.9.6)", "grpcio (==1.51.1)", "imageio (==2.27.0)", "imageio-ffmpeg (==0.4.8)", "jupyter_sphinx (==0.4.0)", "jupyterlab (>=3.2.8)", "matplotlib (==3.7.1)", "numpydoc (==1.5.0)", "pandas (==2.0.0)", "plotly (==5.14.0)", "pypandoc (==1.11)", "pytest-sphinx (==0.5.0)", "pythreejs (==2.4.2)", "pyvista (==0.38.5)", "sphinx (==5.3.0)", "sphinx-autobuild (==2021.3.14)", "sphinx-autodoc-typehints (==1.22)", "sphinx-copybutton (==0.5.1)", "sphinx-gallery (==0.12.2)", "sphinx-notfound-page (==0.8.3)", "sphinxcontrib-websupport (==1.2.4)", "sphinxemoji (==0.2.0)", "vtk (==9.2.6)"]
+tests = ["ansys-dpf-core (==0.8.0)", "autopep8 (==2.0.2)", "matplotlib (==3.7.1)", "pandas (==2.0.0)", "pyansys-tools-report (==0.5.0)", "pytest (==7.2.2)", "pytest-cov (==4.0.0)", "pytest-rerunfailures (==11.1.2)", "pyvista (==0.38.5)", "scipy (==1.10.1)", "vtk (==9.2.6)"]
 
 [[package]]
 name = "ansys-mapdl-reader"
@@ -361,7 +368,7 @@ typing-extensions = "^4.0"
 type = "git"
 url = "https://github.com/ansys-internal/ansys-tools-local-product-launcher.git"
 reference = "main"
-resolved_reference = "e37ff49b99f1a393c949f36340204f987bd7c57b"
+resolved_reference = "83dcf5f5a28c026ca92db78b42494a0cce47dc7a"
 
 [[package]]
 name = "ansys-tools-path"
@@ -2325,6 +2332,25 @@ files = [
 ]
 
 [[package]]
+name = "pyansys-tools-versioning"
+version = "0.3.3"
+description = "PyAnsys Tools Versioning."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyansys-tools-versioning-0.3.3.tar.gz", hash = "sha256:1f6457a81d4f89f7a0fe51c7f52ac427e7dc38989c7e4de8507b76b40166a6a7"},
+    {file = "pyansys_tools_versioning-0.3.3-py3-none-any.whl", hash = "sha256:c2ab624fe110accf00112bd93062b24065ededad967d5882bd65152e70fda20b"},
+]
+
+[package.dependencies]
+importlib-metadata = ">=4.12.0"
+
+[package.extras]
+doc = ["Sphinx (==5.3.0)", "Sphinx-copybutton (==0.5.1)", "ansys_sphinx_theme (==0.8.0)", "numpydoc (==1.5.0)", "sphinx-autoapi (==2.0.0)"]
+tests = ["hypothesis (==6.62.1)", "pytest (==7.2.1)", "pytest-cov (==4.0.0)"]
+
+[[package]]
 name = "pyasn1"
 version = "0.5.0"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
@@ -3340,4 +3366,4 @@ examples = ["ansys-dpf-composites", "ansys-dpf-core", "ansys-mapdl-core", "pyvis
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4" # Plan on supporting only the currently supported versions of Python
-content-hash = "7d7b6084394e7713c6f015295839495850d426d1e94003315eb790f51ba4d5f5"
+content-hash = "73a3c6a77295bb240b8aead78518dbd5194fdbba7453049cf421a4da476f5675"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,18 +32,21 @@ include = ["src/**/docker-compose.yaml"]
 [tool.poetry.dependencies]
 python = ">=3.8,<4" # Plan on supporting only the currently supported versions of Python
 numpy = "^1.22"
-ansys-api-acp = { git = "https://github.com/ansys-internal/ansys-api-acp.git",  branch = "main" }
-ansys-tools-local-product-launcher = { git = "https://github.com/ansys-internal/ansys-tools-local-product-launcher.git", branch = "main" }
-ansys-tools-filetransfer = { git = "https://github.com/ansys-internal/ansys-tools-filetransfer.git", branch = "main" }
 grpcio-health-checking = "^1.43"
 docker = "^6.0.1"
 packaging = ">=15.0"
 typing-extensions = "^4.5.0"
-pyvista = { version = ">=0.36", optional = true }
+ansys-api-acp = { git = "https://github.com/ansys-internal/ansys-api-acp.git",  branch = "main" }
 ansys-tools-path = "^0.2.3"
-ansys-dpf-core = "^0.7"
-ansys-dpf-composites = "^0.1"
-ansys-mapdl-core = "^0.62.1"
+ansys-tools-local-product-launcher = { git = "https://github.com/ansys-internal/ansys-tools-local-product-launcher.git", branch = "main" }
+ansys-tools-filetransfer = { git = "https://github.com/ansys-internal/ansys-tools-filetransfer.git", branch = "main" }
+
+# Dependencies for the examples. Update also the 'dev' group when
+# these are updated.
+ansys-mapdl-core = { version = ">=0.62.1,<1", optional = true }
+ansys-dpf-composites = { version = ">=0.1,<1", optional = true }
+ansys-dpf-core = { version = ">=0.7,<1", optional = true }
+pyvista = { version = ">=0.36", optional = true }
 
 [tool.poetry.group.dev]
 optional = true
@@ -62,9 +65,15 @@ numpydoc = "^1.5.0"
 ansys-sphinx-theme = "^0"
 pypandoc = "^1.10"
 sphinx-gallery = "^0.13.0"
-pyvista = ">=0.36"
 ipykernel = "^6.22.0"
 
+# Repeat optional dependencies from the main group which are
+# included in the 'examples' extra. This is done s.t. the install
+# flag '--with=dev,test' will install all dependencies.
+ansys-mapdl-core = ">=0.62.1,<1"
+ansys-dpf-composites = ">=0.1,<1"
+ansys-dpf-core = ">=0.7,<1"
+pyvista = ">=0.36"
 
 [tool.poetry.group.test]
 optional = true


### PR DESCRIPTION
* Make `ansys-dpf-core` and `ansys-dpf-composites` optional in the main
  dependency group, and extend their possible versions.
* Move `hypothesis` to the `test` dependency group
* Sort dependencies