### PR TITLE
Fix --validate-benchmarks-only flag use in CI

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -161,7 +161,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.BOT_APPLICATION_ID }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Unit testing
@@ -216,8 +216,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.BOT_APPLICATION_ID }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: pyansys-ci-bot
+          password: ${{ secrets.PYANSYS_CI_BOT_PACKAGE_TOKEN }}
 
       - name: Install OS packages
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,8 +43,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.BOT_APPLICATION_ID }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: pyansys-ci-bot
+          password: ${{ secrets.PYANSYS_CI_BOT_PACKAGE_TOKEN }}
 
       - name: Unit testing
         run: |


### PR DESCRIPTION
Fixes when the ``--validate-benchmarks-only`` flag is passed to the benchmarks step
in CI: When the benchmarks are subsequently published, the flag should not be passed,
to run a full benchmark.

The root cause for this is that the ``${{ <condition> && <optionA> || <optionB> }}`` 
workaround used to implement a ternary operator in Github Actions only works correctly
if ``<optionA>`` evaluates to ``true``.