### PR TITLE
Expose server version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -164,7 +164,7 @@ protobuf = ">=3.19,<5"
 type = "git"
 url = "https://github.com/ansys-internal/ansys-api-acp.git"
 reference = "main"
-resolved_reference = "98feedcd67d263b081bcc0f51691c09f0af6a187"
+resolved_reference = "51f44b34784c6215026fdcfd7a2110e6b9dfe2a0"
 
 [[package]]
 name = "ansys-api-mapdl"
@@ -478,7 +478,7 @@ typing-extensions = "^4.0"
 type = "git"
 url = "https://github.com/ansys-internal/ansys-tools-local-product-launcher.git"
 reference = "main"
-resolved_reference = "f62c4a4f2888db6853ba1ef9d5c5b21ae6c8cbd5"
+resolved_reference = "3c7c94ee4d0bdcbc18fee74e498a357ea57f00d7"
 
 [[package]]
 name = "ansys-tools-path"

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,0 +1,8 @@
+from ansys.acp.core import Client
+
+
+def test_server_version(grpc_server):
+    client = Client(server=grpc_server)
+    version = client.server_version
+    assert isinstance(version, str)
+    assert version != ""


### PR DESCRIPTION
Add ``server_version`` property to the `Client` class.

See #269 for discussion regarding the client / server split. 
To expose the version directly on the server, we would need to
add a wrapper class around the `local_product_launcher.ProductInstance`.