### PR TITLE
Add explicit type checks

### DIFF
--- a/src/ansys/acp/core/_tree_objects/boolean_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/boolean_selection_rule.py
@@ -64,6 +64,7 @@ class BooleanSelectionRule(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "BooleanSelectionrule",
         selection_rules: Iterable[LinkedSelectionRule] = (),
         include_rule_type: bool = True,

--- a/src/ansys/acp/core/_tree_objects/cad_geometry.py
+++ b/src/ansys/acp/core/_tree_objects/cad_geometry.py
@@ -89,6 +89,7 @@ class CADGeometry(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "CADGeometry",
         external_path: str = "",
         scale_factor: float = 1.0,

--- a/src/ansys/acp/core/_tree_objects/cutoff_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/cutoff_selection_rule.py
@@ -87,6 +87,7 @@ class CutoffSelectionRule(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "CutoffSelectionrule",
         cutoff_rule_type: CutoffRuleType = CutoffRuleType.GEOMETRY,
         cutoff_geometry: VirtualGeometry | None = None,

--- a/src/ansys/acp/core/_tree_objects/cylindrical_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/cylindrical_selection_rule.py
@@ -76,6 +76,7 @@ class CylindricalSelectionRule(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "CylindricalSelectionrule",
         use_global_coordinate_system: bool = True,
         rosette: Rosette | None = None,

--- a/src/ansys/acp/core/_tree_objects/edge_set.py
+++ b/src/ansys/acp/core/_tree_objects/edge_set.py
@@ -56,6 +56,7 @@ class EdgeSet(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "EdgeSet",
         edge_set_type: EdgeSetType = EdgeSetType.BY_REFERENCE,
         defining_node_labels: Collection[int] = tuple(),

--- a/src/ansys/acp/core/_tree_objects/element_set.py
+++ b/src/ansys/acp/core/_tree_objects/element_set.py
@@ -49,6 +49,7 @@ class ElementSet(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "ElementSet",
         middle_offset: bool = False,
         element_labels: Collection[int] = tuple(),

--- a/src/ansys/acp/core/_tree_objects/fabric.py
+++ b/src/ansys/acp/core/_tree_objects/fabric.py
@@ -67,6 +67,7 @@ class Fabric(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "Fabric",
         material: Material | None = None,
         thickness: float = 0.0,

--- a/src/ansys/acp/core/_tree_objects/geometrical_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/geometrical_selection_rule.py
@@ -84,6 +84,7 @@ class GeometricalSelectionRule(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "GeometricalSelectionrule",
         geometrical_rule_type: GeometricalRuleType = GeometricalRuleType.GEOMETRY,
         geometry: VirtualGeometry | None = None,

--- a/src/ansys/acp/core/_tree_objects/lookup_table_1d.py
+++ b/src/ansys/acp/core/_tree_objects/lookup_table_1d.py
@@ -59,6 +59,7 @@ class LookUpTable1D(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "LookUpTable1D",
         origin: tuple[float, float, float] = (0.0, 0.0, 0.0),
         direction: tuple[float, float, float] = (0.0, 0.0, 0.0),

--- a/src/ansys/acp/core/_tree_objects/lookup_table_1d_column.py
+++ b/src/ansys/acp/core/_tree_objects/lookup_table_1d_column.py
@@ -43,6 +43,7 @@ class LookUpTable1DColumn(LookUpTableColumnBase):
 
     def __init__(
         self,
+        *,
         name: str = "LookUpTable1DColumn",
         value_type: LookUpTableColumnValueType = LookUpTableColumnValueType.SCALAR,
         dimension_type: DimensionType = DimensionType.DIMENSIONLESS,

--- a/src/ansys/acp/core/_tree_objects/lookup_table_3d.py
+++ b/src/ansys/acp/core/_tree_objects/lookup_table_3d.py
@@ -68,6 +68,7 @@ class LookUpTable3D(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "LookUpTable3D",
         interpolation_algorithm: LookUpTable3DInterpolationAlgorithm = LookUpTable3DInterpolationAlgorithm.WEIGHTED_NEAREST_NEIGHBOR,  # noqa: E501
         use_default_search_radius: bool = True,

--- a/src/ansys/acp/core/_tree_objects/lookup_table_3d_column.py
+++ b/src/ansys/acp/core/_tree_objects/lookup_table_3d_column.py
@@ -43,6 +43,7 @@ class LookUpTable3DColumn(LookUpTableColumnBase):
 
     def __init__(
         self,
+        *,
         name: str = "LookUpTable3DColumn",
         value_type: LookUpTableColumnValueType = LookUpTableColumnValueType.SCALAR,
         dimension_type: DimensionType = DimensionType.DIMENSIONLESS,

--- a/src/ansys/acp/core/_tree_objects/lookup_table_column_base.py
+++ b/src/ansys/acp/core/_tree_objects/lookup_table_column_base.py
@@ -49,6 +49,7 @@ class LookUpTableColumnBase(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str,
         value_type: LookUpTableColumnValueType = LookUpTableColumnValueType.SCALAR,
         dimension_type: DimensionType = DimensionType.DIMENSIONLESS,

--- a/src/ansys/acp/core/_tree_objects/material/material.py
+++ b/src/ansys/acp/core/_tree_objects/material/material.py
@@ -109,6 +109,7 @@ class Material(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "Material",
         ply_type: PlyType = "undefined",
         density: ConstantDensity | None = None,

--- a/src/ansys/acp/core/_tree_objects/model.py
+++ b/src/ansys/acp/core/_tree_objects/model.py
@@ -166,6 +166,7 @@ class Model(TreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "ACP Model",
         use_nodal_thicknesses: bool = False,
         draping_offset_correction: bool = False,

--- a/src/ansys/acp/core/_tree_objects/modeling_ply.py
+++ b/src/ansys/acp/core/_tree_objects/modeling_ply.py
@@ -248,6 +248,7 @@ class ModelingPly(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "ModelingPly",
         ply_material: Fabric | None = None,
         oriented_selection_sets: Container[OrientedSelectionSet] = (),

--- a/src/ansys/acp/core/_tree_objects/oriented_selection_set.py
+++ b/src/ansys/acp/core/_tree_objects/oriented_selection_set.py
@@ -112,6 +112,7 @@ class OrientedSelectionSet(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "OrientedSelectionSet",
         element_sets: Sequence[ElementSet] = tuple(),
         orientation_point: tuple[float, float, float] = (0.0, 0.0, 0.0),

--- a/src/ansys/acp/core/_tree_objects/parallel_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/parallel_selection_rule.py
@@ -78,6 +78,7 @@ class ParallelSelectionRule(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "ParallelSelectionrule",
         use_global_coordinate_system: bool = True,
         rosette: Rosette | None = None,

--- a/src/ansys/acp/core/_tree_objects/rosette.py
+++ b/src/ansys/acp/core/_tree_objects/rosette.py
@@ -43,6 +43,7 @@ class Rosette(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "Rosette",
         origin: tuple[float, float, float] = (0.0, 0.0, 0.0),
         dir1: tuple[float, float, float] = (1.0, 0.0, 0.0),

--- a/src/ansys/acp/core/_tree_objects/sensor.py
+++ b/src/ansys/acp/core/_tree_objects/sensor.py
@@ -57,6 +57,7 @@ class Sensor(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "Sensor",
         sensor_type: SensorType = SensorType.SENSOR_BY_AREA,
         active: bool = True,

--- a/src/ansys/acp/core/_tree_objects/spherical_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/spherical_selection_rule.py
@@ -74,6 +74,7 @@ class SphericalSelectionRule(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "SphericalSelectionrule",
         use_global_coordinate_system: bool = True,
         rosette: Rosette | None = None,

--- a/src/ansys/acp/core/_tree_objects/stackup.py
+++ b/src/ansys/acp/core/_tree_objects/stackup.py
@@ -151,6 +151,7 @@ class Stackup(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "Stackup",
         symmetry: SymmetryType = "no_symmetry",
         topdown: bool = True,

--- a/src/ansys/acp/core/_tree_objects/sublaminate.py
+++ b/src/ansys/acp/core/_tree_objects/sublaminate.py
@@ -136,6 +136,7 @@ class SubLaminate(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "SubLaminate",
         symmetry: SymmetryType = "no_symmetry",
         topdown: bool = True,

--- a/src/ansys/acp/core/_tree_objects/tube_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/tube_selection_rule.py
@@ -82,6 +82,7 @@ class TubeSelectionRule(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "TubeSelectionrule",
         edge_set: EdgeSet | None = None,
         outer_radius: float = 1.0,

--- a/src/ansys/acp/core/_tree_objects/variable_offset_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/variable_offset_selection_rule.py
@@ -89,6 +89,7 @@ class VariableOffsetSelectionRule(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "VariableOffsetSelectionrule",
         edge_set: EdgeSet | None = None,
         offsets: LookUpTable1DColumn | None = None,

--- a/src/ansys/acp/core/_tree_objects/virtual_geometry.py
+++ b/src/ansys/acp/core/_tree_objects/virtual_geometry.py
@@ -108,6 +108,7 @@ class VirtualGeometry(CreatableTreeObject, IdTreeObject):
 
     def __init__(
         self,
+        *,
         name: str = "VirtualGeometry",
         sub_shapes: Iterable[str] = (),
     ):

--- a/type_checks/README.md
+++ b/type_checks/README.md
@@ -1,0 +1,7 @@
+# Type checks
+
+This directory contains a set of scripts that are meant to be checked by
+`mypy`. The scripts may not be runnable, but they should check specific
+aspects of the type hints in the code.
+
+These checks run as part of the `mypy-code` pre-commit hook.

--- a/type_checks/create_methods.py
+++ b/type_checks/create_methods.py
@@ -1,0 +1,28 @@
+from typing import Callable
+
+from mypy_extensions import DefaultNamedArg
+from typing_extensions import assert_type
+
+from ansys.acp.core import CADGeometry, Model
+
+model = Model()  # type: ignore
+
+# Test that one of the generated 'create_*' methods has the correct type
+# signature. This ensures that the type checker understands the
+# 'define_create_method' function.
+
+assert_type(
+    model.create_cad_geometry,
+    Callable[
+        [
+            DefaultNamedArg(str, "name"),
+            DefaultNamedArg(str, "external_path"),
+            DefaultNamedArg(float, "scale_factor"),
+            DefaultNamedArg(bool, "use_default_precision"),
+            DefaultNamedArg(float, "precision"),
+            DefaultNamedArg(bool, "use_default_offset"),
+            DefaultNamedArg(float, "offset"),
+        ],
+        CADGeometry,
+    ],
+)

--- a/type_checks/grpc_properties.py
+++ b/type_checks/grpc_properties.py
@@ -1,0 +1,10 @@
+from typing_extensions import assert_type
+
+from ansys.acp.core import Fabric
+
+fabric = Fabric()  # type: ignore
+
+# Test that the type checker understands the grpc properties.
+
+assert_type(fabric.locked, bool)  # read-only property
+assert_type(fabric.thickness, float)  # read-write property

--- a/type_checks/mutable_mapping.py
+++ b/type_checks/mutable_mapping.py
@@ -1,0 +1,10 @@
+from typing_extensions import assert_type
+
+from ansys.acp.core import Model, ModelingGroup
+
+model = Model()  # type: ignore
+
+# Test that the type checker understands the mutable mapping defined
+# via 'define_mutable_mapping'.
+
+assert_type(model.modeling_groups["key"], ModelingGroup)


### PR DESCRIPTION
Add explicit checks to ensure that `mypy` can correctly infer the types of certain PyACP objects.

This is done by adding dummy scripts and using `typing.assert_type` to check for certain types.
The scripts are generally not runnable, since the set-up takes some shortcuts, explicitly ignoring the resulting type errors.

Other changes:
- Make all arguments in the `__init__` methods of tree objects keyword only.