### PR TITLE
Improve __repr__ of collection types

### DIFF
--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
@@ -279,8 +279,10 @@ class EdgePropertyList(MutableSequence[ValueT]):
         return list(self) == other
 
     def __repr__(self) -> str:
-        entries = ", ".join(f"{item}" for item in self._object_list)
-        return f"{self._parent_object.name} - {self._name}({entries})"
+        return (
+            f"<{self.__class__.__name__}[{self._object_type.__name__}] "
+            + f"with parent {self._parent_object!r}, entries {self._object_list!r}>"
+        )
 
 
 def define_edge_property_list(

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/linked_object_list.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/linked_object_list.py
@@ -214,6 +214,9 @@ class LinkedObjectList(MutableSequence[ValueT]):
     def __eq__(self, other: Any) -> Any:
         return list(self) == other
 
+    def __repr__(self) -> str:
+        return f"<LinkedObjectList([{', '.join(repr(val) for val in self)}])>"
+
 
 ChildT = TypeVar("ChildT", bound=CreatableTreeObject)
 

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/mapping.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/mapping.py
@@ -113,9 +113,9 @@ class Mapping(Generic[ValueT]):
 
             collection_label = self._collection_path.value.rsplit("/", 1)[-1]
             value_type = object_registry[collection_label]
-            return f"{self.__class__.__name__}[{value_type.__name__}] with keys {list(self)}"
+            return f"<{self.__class__.__name__}[{value_type.__name__}] with keys {list(self)}>"
         except:
-            return super().__str__()
+            return super().__repr__()
 
 
 class MutableMapping(Mapping[CreatableValueT]):


### PR DESCRIPTION
Improve the string representation of the collection types in the following ways:
* `LinkedObjectList`: add a custom `__repr__` which shows the linked objects
* `MutableMapping` add a custom `__repr__` which shows the value type,
  and mapping keys
* `EdgePropertyList`: adapt the style to match the tree objects and other collections

Closes #391 