### PR TITLE
Handle missing mesh query data

### DIFF
--- a/examples/001_basic_flat_plate.py
+++ b/examples/001_basic_flat_plate.py
@@ -115,7 +115,9 @@ oss = model.create_oriented_selection_set(
 
 model.update()
 
-plotter = get_directions_plotter(model=model, components=[oss.elemental_data.orientation])
+orientation = oss.elemental_data.orientation
+assert orientation is not None
+plotter = get_directions_plotter(model=model, components=[orientation])
 plotter.show()
 
 
@@ -139,9 +141,11 @@ model.update()
 modeling_ply = model.modeling_groups["modeling_group"].modeling_plies["ply_4_-45_UD"]
 
 
+fiber_direction = modeling_ply.elemental_data.fiber_direction
+assert fiber_direction is not None
 plotter = get_directions_plotter(
     model=model,
-    components=[modeling_ply.elemental_data.fiber_direction],
+    components=[fiber_direction],
 )
 
 plotter.show()

--- a/examples/solve_class40.py
+++ b/examples/solve_class40.py
@@ -172,10 +172,10 @@ model.update()
 
 plotter = pyvista.Plotter()
 plotter.add_mesh(model.mesh.to_pyvista(), color="white")
+orientation = oss_hull.elemental_data.orientation
+assert orientation is not None
 plotter.add_mesh(
-    oss_hull.elemental_data.orientation.get_pyvista_glyphs(
-        mesh=model.mesh, factor=0.2, culling_factor=5
-    ),
+    orientation.get_pyvista_glyphs(mesh=model.mesh, factor=0.2, culling_factor=5),
     color="blue",
 )
 plotter.show()
@@ -235,20 +235,26 @@ print(len(model.modeling_groups["keeltower"].modeling_plies))
 # Show the thickness of one of the plies
 model.update()
 modeling_ply = model.modeling_groups["deck"].modeling_plies["eglass_ud_02mm_0.5"]
-modeling_ply.elemental_data.thickness.get_pyvista_mesh(mesh=model.mesh).plot()
+thickness = modeling_ply.elemental_data.thickness
+assert thickness is not None
+thickness.get_pyvista_mesh(mesh=model.mesh).plot()
 
 # %%
 # Show the ply offsets, scaled by a factor of 200
 plotter = pyvista.Plotter()
 plotter.add_mesh(model.mesh.to_pyvista(), color="white")
+ply_offset = modeling_ply.nodal_data.ply_offset
+assert ply_offset is not None
 plotter.add_mesh(
-    modeling_ply.nodal_data.ply_offset.get_pyvista_glyphs(mesh=model.mesh, factor=200),
+    ply_offset.get_pyvista_glyphs(mesh=model.mesh, factor=200),
 )
 plotter.show()
 
 # %%
 # Show the thickness of the entire lay-up
-model.elemental_data.thickness.get_pyvista_mesh(mesh=model.mesh).plot()
+thickness = model.elemental_data.thickness
+assert thickness is not None
+thickness.get_pyvista_mesh(mesh=model.mesh).plot()
 
 # %%
 #

--- a/src/ansys/acp/core/_tree_objects/_mesh_data.py
+++ b/src/ansys/acp/core/_tree_objects/_mesh_data.py
@@ -249,7 +249,7 @@ def _check_field_type(klass: Any, field_name: str, actual_field_type: str) -> No
     )
     if len(declared_field_types) != 1:
         raise RuntimeError("Failed to find field in dataclass.")
-    declared_field_type = declared_field_types[0]
+    declared_field_type = declared_field_types[0].removesuffix(" | None")
     if declared_field_type != actual_field_type:
         raise RuntimeError(
             f"Declared type does not match actual data type. "

--- a/src/ansys/acp/core/_tree_objects/analysis_ply.py
+++ b/src/ansys/acp/core/_tree_objects/analysis_ply.py
@@ -32,33 +32,33 @@ __all__ = ["AnalysisPly", "AnalysisPlyElementalData", "AnalysisPlyNodalData"]
 class AnalysisPlyElementalData(ElementalData):
     """Represents elemental data for a Analysis Ply."""
 
-    normal: VectorData
-    orientation: VectorData
-    reference_direction: VectorData
-    fiber_direction: VectorData
-    draped_fiber_direction: VectorData
-    transverse_direction: VectorData
-    draped_transverse_direction: VectorData
-    thickness: ScalarData[np.float64]
-    relative_thickness_correction: ScalarData[np.float64]
-    design_angle: ScalarData[np.float64]
-    shear_angle: ScalarData[np.float64]
-    draped_fiber_angle: ScalarData[np.float64]
-    draped_transverse_angle: ScalarData[np.float64]
-    area: ScalarData[np.float64]
-    price: ScalarData[np.float64]
-    volume: ScalarData[np.float64]
-    mass: ScalarData[np.float64]
-    offset: ScalarData[np.float64]
-    material_1_direction: VectorData
-    cog: VectorData
+    normal: VectorData | None = None
+    orientation: VectorData | None = None
+    reference_direction: VectorData | None = None
+    fiber_direction: VectorData | None = None
+    draped_fiber_direction: VectorData | None = None
+    transverse_direction: VectorData | None = None
+    draped_transverse_direction: VectorData | None = None
+    thickness: ScalarData[np.float64] | None = None
+    relative_thickness_correction: ScalarData[np.float64] | None = None
+    design_angle: ScalarData[np.float64] | None = None
+    shear_angle: ScalarData[np.float64] | None = None
+    draped_fiber_angle: ScalarData[np.float64] | None = None
+    draped_transverse_angle: ScalarData[np.float64] | None = None
+    area: ScalarData[np.float64] | None = None
+    price: ScalarData[np.float64] | None = None
+    volume: ScalarData[np.float64] | None = None
+    mass: ScalarData[np.float64] | None = None
+    offset: ScalarData[np.float64] | None = None
+    material_1_direction: VectorData | None = None
+    cog: VectorData | None = None
 
 
 @dataclasses.dataclass
 class AnalysisPlyNodalData(NodalData):
     """Represents nodal data for a Analysis Ply."""
 
-    ply_offset: VectorData
+    ply_offset: VectorData | None = None
 
 
 @mark_grpc_properties

--- a/src/ansys/acp/core/_tree_objects/boolean_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/boolean_selection_rule.py
@@ -40,7 +40,7 @@ __all__ = [
 class BooleanSelectionRuleElementalData(ElementalData):
     """Represents elemental data for a Boolean Selection Rule."""
 
-    normal: VectorData
+    normal: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/cutoff_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/cutoff_selection_rule.py
@@ -50,7 +50,7 @@ __all__ = [
 class CutoffSelectionRuleElementalData(ElementalData):
     """Represents elemental data for a Cutoff Selection Rule."""
 
-    normal: VectorData
+    normal: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/cylindrical_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/cylindrical_selection_rule.py
@@ -41,7 +41,7 @@ __all__ = [
 class CylindricalSelectionRuleElementalData(ElementalData):
     """Represents elemental data for a Cylindrical Selection Rule."""
 
-    normal: VectorData
+    normal: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/element_set.py
+++ b/src/ansys/acp/core/_tree_objects/element_set.py
@@ -39,7 +39,7 @@ __all__ = [
 class ElementSetElementalData(ElementalData):
     """Represents elemental data for an Element Set."""
 
-    normal: VectorData
+    normal: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/geometrical_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/geometrical_selection_rule.py
@@ -47,7 +47,7 @@ __all__ = [
 class GeometricalSelectionRuleElementalData(ElementalData):
     """Represents elemental data for a Geometrical Selection Rule."""
 
-    normal: VectorData
+    normal: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/model.py
+++ b/src/ansys/acp/core/_tree_objects/model.py
@@ -139,15 +139,15 @@ class MeshData:
 class ModelElementalData(ElementalData):
     """Represents elemental data for a Model."""
 
-    normal: VectorData
-    thickness: ScalarData[np.float64]
-    relative_thickness_correction: ScalarData[np.float64]
-    area: ScalarData[np.float64]
-    price: ScalarData[np.float64]
-    volume: ScalarData[np.float64]
-    mass: ScalarData[np.float64]
-    offset: ScalarData[np.float64]
-    cog: VectorData
+    normal: VectorData | None = None
+    thickness: ScalarData[np.float64] | None = None
+    relative_thickness_correction: ScalarData[np.float64] | None = None
+    area: ScalarData[np.float64] | None = None
+    price: ScalarData[np.float64] | None = None
+    volume: ScalarData[np.float64] | None = None
+    mass: ScalarData[np.float64] | None = None
+    offset: ScalarData[np.float64] | None = None
+    cog: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/modeling_group.py
+++ b/src/ansys/acp/core/_tree_objects/modeling_group.py
@@ -25,7 +25,7 @@ __all__ = ["ModelingGroup"]
 class ModelingGroupElementalData(ElementalData):
     """Represents elemental data for an Modeling Group."""
 
-    normal: VectorData
+    normal: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/modeling_ply.py
+++ b/src/ansys/acp/core/_tree_objects/modeling_ply.py
@@ -58,32 +58,32 @@ __all__ = ["ModelingPly", "ModelingPlyElementalData", "ModelingPlyNodalData", "T
 class ModelingPlyElementalData(ElementalData):
     """Represents elemental data for a Modeling Ply."""
 
-    normal: VectorData
-    orientation: VectorData
-    reference_direction: VectorData
-    fiber_direction: VectorData
-    draped_fiber_direction: VectorData
-    transverse_direction: VectorData
-    draped_transverse_direction: VectorData
-    thickness: ScalarData[np.float64]
-    relative_thickness_correction: ScalarData[np.float64]
-    design_angle: ScalarData[np.float64]
-    shear_angle: ScalarData[np.float64]
-    draped_fiber_angle: ScalarData[np.float64]
-    draped_transverse_angle: ScalarData[np.float64]
-    area: ScalarData[np.float64]
-    price: ScalarData[np.float64]
-    volume: ScalarData[np.float64]
-    mass: ScalarData[np.float64]
-    offset: ScalarData[np.float64]
-    cog: VectorData
+    normal: VectorData | None = None
+    orientation: VectorData | None = None
+    reference_direction: VectorData | None = None
+    fiber_direction: VectorData | None = None
+    draped_fiber_direction: VectorData | None = None
+    transverse_direction: VectorData | None = None
+    draped_transverse_direction: VectorData | None = None
+    thickness: ScalarData[np.float64] | None = None
+    relative_thickness_correction: ScalarData[np.float64] | None = None
+    design_angle: ScalarData[np.float64] | None = None
+    shear_angle: ScalarData[np.float64] | None = None
+    draped_fiber_angle: ScalarData[np.float64] | None = None
+    draped_transverse_angle: ScalarData[np.float64] | None = None
+    area: ScalarData[np.float64] | None = None
+    price: ScalarData[np.float64] | None = None
+    volume: ScalarData[np.float64] | None = None
+    mass: ScalarData[np.float64] | None = None
+    offset: ScalarData[np.float64] | None = None
+    cog: VectorData | None = None
 
 
 @dataclasses.dataclass
 class ModelingPlyNodalData(NodalData):
     """Represents nodal data for a Modeling Ply."""
 
-    ply_offset: VectorData
+    ply_offset: VectorData | None = None
 
 
 class TaperEdge(GenericEdgePropertyType):

--- a/src/ansys/acp/core/_tree_objects/oriented_selection_set.py
+++ b/src/ansys/acp/core/_tree_objects/oriented_selection_set.py
@@ -59,9 +59,9 @@ __all__ = [
 class OrientedSelectionSetElementalData(ElementalData):
     """Represents elemental data for an Oriented Selection Set."""
 
-    normal: VectorData
-    orientation: VectorData
-    reference_direction: VectorData
+    normal: VectorData | None = None
+    orientation: VectorData | None = None
+    reference_direction: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/parallel_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/parallel_selection_rule.py
@@ -41,7 +41,7 @@ __all__ = [
 class ParallelSelectionRuleElementalData(ElementalData):
     """Represents elemental data for a Parallel Selection Rule."""
 
-    normal: VectorData
+    normal: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/production_ply.py
+++ b/src/ansys/acp/core/_tree_objects/production_ply.py
@@ -34,25 +34,25 @@ __all__ = ["ProductionPly", "ProductionPlyElementalData", "ProductionPlyNodalDat
 class ProductionPlyElementalData(ElementalData):
     """Represents elemental data for a Production Ply."""
 
-    normal: VectorData
-    orientation: VectorData
-    reference_direction: VectorData
-    fiber_direction: VectorData
-    draped_fiber_direction: VectorData
-    transverse_direction: VectorData
-    draped_transverse_direction: VectorData
-    thickness: ScalarData[np.float64]
-    relative_thickness_correction: ScalarData[np.float64]
-    design_angle: ScalarData[np.float64]
-    shear_angle: ScalarData[np.float64]
-    draped_fiber_angle: ScalarData[np.float64]
-    draped_transverse_angle: ScalarData[np.float64]
-    area: ScalarData[np.float64]
-    price: ScalarData[np.float64]
-    volume: ScalarData[np.float64]
-    mass: ScalarData[np.float64]
-    offset: ScalarData[np.float64]
-    cog: VectorData
+    normal: VectorData | None = None
+    orientation: VectorData | None = None
+    reference_direction: VectorData | None = None
+    fiber_direction: VectorData | None = None
+    draped_fiber_direction: VectorData | None = None
+    transverse_direction: VectorData | None = None
+    draped_transverse_direction: VectorData | None = None
+    thickness: ScalarData[np.float64] | None = None
+    relative_thickness_correction: ScalarData[np.float64] | None = None
+    design_angle: ScalarData[np.float64] | None = None
+    shear_angle: ScalarData[np.float64] | None = None
+    draped_fiber_angle: ScalarData[np.float64] | None = None
+    draped_transverse_angle: ScalarData[np.float64] | None = None
+    area: ScalarData[np.float64] | None = None
+    price: ScalarData[np.float64] | None = None
+    volume: ScalarData[np.float64] | None = None
+    mass: ScalarData[np.float64] | None = None
+    offset: ScalarData[np.float64] | None = None
+    cog: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/spherical_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/spherical_selection_rule.py
@@ -41,7 +41,7 @@ __all__ = [
 class SphericalSelectionRuleElementalData(ElementalData):
     """Represents elemental data for a Spherical Selection Rule."""
 
-    normal: VectorData
+    normal: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/tube_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/tube_selection_rule.py
@@ -41,7 +41,7 @@ __all__ = [
 class TubeSelectionRuleElementalData(ElementalData):
     """Represents elemental data for a Tube Selection Rule."""
 
-    normal: VectorData
+    normal: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/src/ansys/acp/core/_tree_objects/variable_offset_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/variable_offset_selection_rule.py
@@ -46,7 +46,7 @@ __all__ = [
 class VariableOffsetSelectionRuleElementalData(ElementalData):
     """Represents elemental data for a VariableOffset Selection Rule."""
 
-    normal: VectorData
+    normal: VectorData | None = None
 
 
 @dataclasses.dataclass

--- a/tests/unittests/test_modeling_ply.py
+++ b/tests/unittests/test_modeling_ply.py
@@ -249,6 +249,56 @@ def test_elemental_data(simple_modeling_ply):
     numpy.testing.assert_allclose(data.cog.values, np.array([[0.0, 0.0, 5e-5]]))
 
 
+def test_elemental_data_incomplete(simple_modeling_ply, minimal_complete_model):
+    """Test the elemental data when draping properties are missing."""
+    # draping-related properties are not propagated up to the modeling ply
+    # when it has more than one production ply
+    simple_modeling_ply.number_of_layers = 2
+    minimal_complete_model.update()
+
+    data = simple_modeling_ply.elemental_data
+    numpy.testing.assert_allclose(data.element_labels.values, np.array([1]))
+    numpy.testing.assert_allclose(data.normal.values, np.array([[0.0, 0.0, 1.0]]))
+
+    numpy.testing.assert_allclose(
+        data.orientation.values,
+        np.array([[0.0, 0.0, 1.0]]),
+        atol=1e-12,
+    )
+    numpy.testing.assert_allclose(
+        data.reference_direction.values,
+        np.array([[1.0, 0.0, 0.0]]),
+        atol=1e-12,
+    )
+    numpy.testing.assert_allclose(
+        data.fiber_direction.values,
+        np.array([[1.0, 0.0, 0.0]]),
+        atol=1e-12,
+    )
+    assert data.draped_fiber_direction is None
+    numpy.testing.assert_allclose(
+        data.transverse_direction.values,
+        np.array([[0.0, 1.0, 0.0]]),
+        atol=1e-12,
+    )
+    assert data.draped_transverse_direction is None
+
+    numpy.testing.assert_allclose(data.thickness.values, np.array([2e-4]))
+    numpy.testing.assert_allclose(data.relative_thickness_correction.values, np.array([1.0]))
+
+    numpy.testing.assert_allclose(data.design_angle.values, np.array([0.0]))
+    assert data.shear_angle is None
+    assert data.draped_fiber_angle is None
+    assert data.draped_transverse_angle is None
+
+    numpy.testing.assert_allclose(data.area.values, np.array([9e4]))
+    numpy.testing.assert_allclose(data.price.values, np.array([0.0]))
+    numpy.testing.assert_allclose(data.volume.values, np.array([18.0]))
+    numpy.testing.assert_allclose(data.mass.values, np.array([14.130e-08]))
+    numpy.testing.assert_allclose(data.offset.values, np.array([1e-4]))
+    numpy.testing.assert_allclose(data.cog.values, np.array([[0.0, 0.0, 1e-4]]))
+
+
 def test_nodal_data(simple_modeling_ply):
     data = simple_modeling_ply.nodal_data
     numpy.testing.assert_allclose(data.node_labels.values, np.array([1, 2, 3, 4]))

--- a/type_checks/plots.py
+++ b/type_checks/plots.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 from typing_extensions import assert_type
 
@@ -8,8 +10,8 @@ model = Model()  # type: ignore
 
 modeling_ply = model.modeling_groups["key"].modeling_plies["key"]
 assert_type(modeling_ply.elemental_data, ModelingPlyElementalData)
-assert_type(modeling_ply.elemental_data.normal, VectorData)
-assert_type(modeling_ply.elemental_data.thickness, ScalarData[np.float64])
+assert_type(modeling_ply.elemental_data.normal, Optional[VectorData])
+assert_type(modeling_ply.elemental_data.thickness, Optional[ScalarData[np.float64]])
 assert_type(modeling_ply.elemental_data.element_labels, ScalarData[np.int32])
 assert_type(modeling_ply.nodal_data.node_labels, ScalarData[np.int32])
-assert_type(modeling_ply.nodal_data.ply_offset, VectorData)
+assert_type(modeling_ply.nodal_data.ply_offset, Optional[VectorData])


### PR DESCRIPTION
Allow for missing data in mesh queries, setting the corresponding component of the ElementalData or NodalData to None.

Adapt example code to check for None where necessary.

Add test for partial elemental data on a ModelingPly.

Closes #272.