### PR TITLE
Add limitations section

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -77,12 +77,8 @@ optimization of composite structures.
 
             Information on how to contribute to PyACP.
 
-Key features
-^^^^^^^^^^^^
-
-TODO
 
 Limitations
 ^^^^^^^^^^^
 
-TODO
+Currently, only shell workflows are supported. Solid models can not yet be defined using PyACP.


### PR DESCRIPTION
Add 'Limitations' section to landing page. Remove 'Key features', since the header blurb already contains these.

Closes #375 