### PR TITLE
Remove Fabric.locked

### DIFF
--- a/src/ansys/acp/core/_tree_objects/fabric.py
+++ b/src/ansys/acp/core/_tree_objects/fabric.py
@@ -92,7 +92,6 @@ class Fabric(CreatableTreeObject, IdTreeObject):
     def _create_stub(self) -> fabric_pb2_grpc.ObjectServiceStub:
         return fabric_pb2_grpc.ObjectServiceStub(self._channel)
 
-    locked: ReadOnlyProperty[bool] = grpc_data_property_read_only("properties.locked")
     status = grpc_data_property_read_only("properties.status", from_protobuf=status_type_from_pb)
     area_weight: ReadOnlyProperty[float] = grpc_data_property_read_only("properties.area_weight")
 

--- a/type_checks/grpc_properties.py
+++ b/type_checks/grpc_properties.py
@@ -1,10 +1,11 @@
 from typing_extensions import assert_type
 
-from ansys.acp.core import Fabric
+from ansys.acp.core import Fabric, Rosette
 
+rosette = Rosette()  # type: ignore
 fabric = Fabric()  # type: ignore
 
 # Test that the type checker understands the grpc properties.
 
-assert_type(fabric.locked, bool)  # read-only property
+assert_type(rosette.locked, bool)  # read-only property
 assert_type(fabric.thickness, float)  # read-write property


### PR DESCRIPTION
The `locked` attribute of the fabric is not present in the API; remove it.

Closes #98 