### PR TITLE
Allow linking to CutoffSelectionRule from ModelingPly

### DIFF
--- a/src/ansys/acp/core/_tree_objects/linked_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/linked_selection_rule.py
@@ -29,13 +29,14 @@ if typing.TYPE_CHECKING:
     from .boolean_selection_rule import BooleanSelectionRule
 
     _LINKABLE_SELECTION_RULE_TYPES = Union[
-        ParallelSelectionRule,
+        BooleanSelectionRule,
+        CutoffSelectionRule,
         CylindricalSelectionRule,
+        GeometricalSelectionRule,
+        ParallelSelectionRule,
         SphericalSelectionRule,
         TubeSelectionRule,
-        GeometricalSelectionRule,
         VariableOffsetSelectionRule,
-        BooleanSelectionRule,
     ]
 
 
@@ -87,12 +88,16 @@ class LinkedSelectionRule(GenericEdgePropertyType):
         parameter_1: float = 0.0,
         parameter_2: float = 0.0,
     ):
+        # The '_callback_apply_changes' needs to be set first, otherwise the
+        # setter methods will not work. We go through the setters instead of
+        # directly setting the attributes to ensure the setter validation is
+        # performed.
+        self._callback_apply_changes: Callable[[], None] | None = None
         self.selection_rule = selection_rule
         self.operation_type = operation_type
         self.template_rule = template_rule
         self.parameter_1 = parameter_1
         self.parameter_2 = parameter_2
-        self._callback_apply_changes: Callable[[], None] | None = None
 
     @property
     def selection_rule(self) -> _LINKABLE_SELECTION_RULE_TYPES:

--- a/tests/unittests/test_modeling_ply.py
+++ b/tests/unittests/test_modeling_ply.py
@@ -5,6 +5,7 @@ import pyvista
 
 from ansys.acp.core import (
     BooleanOperationType,
+    CutoffSelectionRule,
     DrapingType,
     ElementalDataType,
     Fabric,
@@ -404,3 +405,16 @@ def test_linked_selection_rule_parameters(simple_modeling_ply, minimal_complete_
     linked_rule_in_ply = simple_modeling_ply.selection_rules[0]
     linked_rule_in_ply.parameter_1 = 1
     assert linked_parallel_rule.parameter_1 == simple_modeling_ply.selection_rules[0].parameter_1
+
+
+@pytest.mark.parametrize(
+    "operation_type", [e for e in BooleanOperationType if e != BooleanOperationType.INTERSECT]
+)
+def test_linked_cutoff_selection_rule_operation_type(operation_type):
+    """Check that CutoffSelectionRule only allows INTERSECT operation type."""
+    with pytest.raises(ValueError) as exc:
+        LinkedSelectionRule(
+            selection_rule=CutoffSelectionRule(),  # type: ignore
+            operation_type=operation_type,
+        )
+    assert "INTERSECT" in str(exc.value)


### PR DESCRIPTION
Add the CutoffSelectionRule to the allowed selection rule types if the parent is not a BooleanSelectionRule.

Fix the docstring of LinkedSelectionRule, since CutoffSelectionRule and BooleanSelectionRule are disallowed only when the parent is a BoolenSelectionRule (not for ModelingPly).

Add a check for the operation type when linking to a CutoffSelectionRule, to avoid a hidden conversion.

Closes #412