### PR TITLE
Add conversion from list to numpy array for LookUpTableColumn

### DIFF
--- a/src/ansys/acp/core/_tree_objects/lookup_table_column_base.py
+++ b/src/ansys/acp/core/_tree_objects/lookup_table_column_base.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 import numpy as np
 import numpy.typing as npt
 
-from .._utils.array_conversions import to_ND_double_array_from_numpy, to_numpy
+from .._utils.array_conversions import to_ND_double_array_from_numpy_or_list, to_numpy
 from .._utils.property_protocols import ReadWriteProperty
 from ._grpc_helpers.property_helper import (
     grpc_data_property,
@@ -81,5 +81,5 @@ class LookUpTableColumnBase(CreatableTreeObject, IdTreeObject):
     data: ReadWriteProperty[npt.NDArray[np.float64], npt.NDArray[np.float64]] = grpc_data_property(
         "properties.data",
         from_protobuf=to_numpy,
-        to_protobuf=to_ND_double_array_from_numpy,
+        to_protobuf=to_ND_double_array_from_numpy_or_list,
     )

--- a/src/ansys/acp/core/_utils/array_conversions.py
+++ b/src/ansys/acp/core/_utils/array_conversions.py
@@ -25,9 +25,10 @@ def to_tuple_from_1D_array(array: Union[IntArray, DoubleArray]) -> tuple[Any, ..
     return tuple(array.data)
 
 
-def to_ND_double_array_from_numpy(data: npt.NDArray[np.float64]) -> DoubleArray:
-    """Convert a numpy array to a DoubleArray protobuf message."""
-    return DoubleArray(shape=list(data.shape), data=data.flatten())
+def to_ND_double_array_from_numpy_or_list(data: npt.NDArray[np.float64]) -> DoubleArray:
+    """Convert a list or numpy array to a DoubleArray protobuf message."""
+    data_np = np.array(data)
+    return DoubleArray(shape=list(data_np.shape), data=data_np.flatten())
 
 
 @overload

--- a/tests/unittests/test_lookup_table_column.py
+++ b/tests/unittests/test_lookup_table_column.py
@@ -41,12 +41,17 @@ def column_value_type(request):
     return request.param
 
 
-@pytest.fixture
-def column_data(num_points, column_value_type):
+@pytest.fixture(params=[False, True])  # Param controls whether the data is converted to a list
+def column_data(num_points, column_value_type, request):
     if column_value_type == LookUpTableColumnValueType.SCALAR:
-        return np.random.rand(num_points)
+        res = np.random.rand(num_points)
     elif column_value_type == LookUpTableColumnValueType.DIRECTION:
-        return np.random.rand(num_points, 3)
+        res = np.random.rand(num_points, 3)
+    if request.param:
+        if num_points == 0 and column_value_type == LookUpTableColumnValueType.DIRECTION:
+            pytest.xfail("Passing empty lists as directional data is not yet supported.")
+        return res.tolist()
+    return res
 
 
 @pytest.fixture


### PR DESCRIPTION
Automatically convert lists to numpy arrays for setting lookup table column data.

Note that using an empty list for directional data is not yet supported, since we cannot determine the correct shape (0, 3) in the conversion.
This is intended to be addressed by a backend PR (allowing empty data with shape (0,) regardless of the target dimensionality), even though we could *in principle* solve this by injecting the ``dimension_type`` into the conversion function.

Closes #426.