### PR TITLE
Define _GRPC_PROPERTIES in GrpcObjectBase

### DIFF
--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/protocols.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/protocols.py
@@ -124,7 +124,7 @@ class GrpcObjectBase(Protocol):
     """Interface definition for objects which are backed by a gRPC API."""
 
     __slots__: Iterable[str] = tuple()
-    _GRPC_PROPERTIES: tuple[str, ...]
+    _GRPC_PROPERTIES: tuple[str, ...] = tuple()
 
     def __str__(self) -> str:
         string_items = []

--- a/tests/unittests/test_modeling_ply.py
+++ b/tests/unittests/test_modeling_ply.py
@@ -419,7 +419,7 @@ def test_linked_cutoff_selection_rule_operation_type(operation_type):
     """Check that CutoffSelectionRule only allows INTERSECT operation type."""
     with pytest.raises(ValueError) as exc:
         LinkedSelectionRule(
-            selection_rule=CutoffSelectionRule(),  # type: ignore
+            selection_rule=CutoffSelectionRule(),
             operation_type=operation_type,
         )
     assert "INTERSECT" in str(exc.value)

--- a/tests/unittests/test_object_permanence.py
+++ b/tests/unittests/test_object_permanence.py
@@ -42,7 +42,7 @@ def test_object_identity_after_deletion(model):
 
 def test_unstored():
     """Check that unstored objects have unique identities."""
-    assert pyacp.ModelingPly() is not pyacp.ModelingPly()  # type: ignore
+    assert pyacp.ModelingPly() is not pyacp.ModelingPly()
 
 
 def test_mapping_identity(model):
@@ -96,7 +96,7 @@ def test_linked_object_list_parent_deleted(model):
 
 def test_linked_object_list_parent_store(model):
     """Check that the linked object list identity is unique even after its parent is stored."""
-    oss = pyacp.OrientedSelectionSet()  # type: ignore
+    oss = pyacp.OrientedSelectionSet()
     element_sets = oss.element_sets
     oss.store(parent=model)
     oss_id = oss.id
@@ -123,7 +123,7 @@ def test_edge_property_list_parent_deleted(model):
 
 def test_edge_property_list_parent_store(model):
     """Check that the edge property list identity is unique even after its parent is stored."""
-    stackup = pyacp.Stackup()  # type: ignore
+    stackup = pyacp.Stackup()
     fabrics = stackup.fabrics
     stackup.store(parent=model)
     stackup_id = stackup.id

--- a/type_checks/add_methods.py
+++ b/type_checks/add_methods.py
@@ -16,7 +16,7 @@ from ansys.acp.core import (
     VariableOffsetSelectionRule,
 )
 
-boolean_rule = BooleanSelectionRule()  # type: ignore
+boolean_rule = BooleanSelectionRule()
 
 # Test that one of the generated 'create_*' methods has the correct type
 # signature. This ensures that the type checker understands the

--- a/type_checks/create_methods.py
+++ b/type_checks/create_methods.py
@@ -5,7 +5,7 @@ from typing_extensions import assert_type
 
 from ansys.acp.core import CADGeometry, Model
 
-model = Model()  # type: ignore
+model = Model()
 
 # Test that one of the generated 'create_*' methods has the correct type
 # signature. This ensures that the type checker understands the

--- a/type_checks/grpc_properties.py
+++ b/type_checks/grpc_properties.py
@@ -2,8 +2,8 @@ from typing_extensions import assert_type
 
 from ansys.acp.core import Fabric, Rosette
 
-rosette = Rosette()  # type: ignore
-fabric = Fabric()  # type: ignore
+rosette = Rosette()
+fabric = Fabric()
 
 # Test that the type checker understands the grpc properties.
 

--- a/type_checks/mutable_mapping.py
+++ b/type_checks/mutable_mapping.py
@@ -2,7 +2,7 @@ from typing_extensions import assert_type
 
 from ansys.acp.core import Model, ModelingGroup
 
-model = Model()  # type: ignore
+model = Model()
 
 # Test that the type checker understands the mutable mapping defined
 # via 'define_mutable_mapping'.

--- a/type_checks/plots.py
+++ b/type_checks/plots.py
@@ -6,7 +6,7 @@ from typing_extensions import assert_type
 from ansys.acp.core import Model, ScalarData, VectorData
 from ansys.acp.core._tree_objects.modeling_ply import ModelingPlyElementalData
 
-model = Model()  # type: ignore
+model = Model()
 
 modeling_ply = model.modeling_groups["key"].plies["key"]
 assert_type(modeling_ply.elemental_data, ModelingPlyElementalData)


### PR DESCRIPTION
Define the _GRPC_PROPERTIES class attribute as an empty tuple in the GrpcObjectBase class, instead of only declaring its type.

This makes mypy understand that the attribute is set; otherwise it does not recognize this since the attribute is set dynamically in the `mark_grpc_properties` class decorator.

Closes #419.