### PR TITLE
Revert renaming 'modeling_plies' to 'plies'

### DIFF
--- a/doc/source/user_guide/howto/visualize_model.rst
+++ b/doc/source/user_guide/howto/visualize_model.rst
@@ -54,7 +54,7 @@ Visualizing the model
     .. pyvista-plot::
         :context:
 
-        >>> modeling_ply = model.modeling_groups['nose'].plies['mp.nose.4']
+        >>> modeling_ply = model.modeling_groups['nose'].modeling_plies['mp.nose.4']
         >>> elemental_data = modeling_ply.elemental_data
         >>> directions_plotter = pyacp.get_directions_plotter(
         ...     model=model,
@@ -102,7 +102,7 @@ Visualizing the model
     .. pyvista-plot::
         :context:
 
-        >>> production_ply = model.modeling_groups['nose'].plies['mp.nose.6'].production_plies['ProductionPly.20']
+        >>> production_ply = model.modeling_groups['nose'].modeling_plies['mp.nose.6'].production_plies['ProductionPly.20']
         >>> ply_offset = production_ply.nodal_data.ply_offset
         >>> ply_offset.get_pyvista_glyphs(mesh=model.mesh, scaling_factor=6., culling_factor=5).plot()
 

--- a/examples/001_basic_flat_plate.py
+++ b/examples/001_basic_flat_plate.py
@@ -142,7 +142,7 @@ model.update()
 
 # %%
 # Show the fiber directions of a specific ply.
-modeling_ply = model.modeling_groups["modeling_group"].plies["ply_4_-45_UD"]
+modeling_ply = model.modeling_groups["modeling_group"].modeling_plies["ply_4_-45_UD"]
 
 
 fiber_direction = modeling_ply.elemental_data.fiber_direction

--- a/examples/003_basic_rules.py
+++ b/examples/003_basic_rules.py
@@ -74,7 +74,7 @@ parallel_rule = model.create_parallel_selection_rule(
     upper_limit=1,
 )
 
-modeling_ply = model.modeling_groups["modeling_group"].plies["ply"]
+modeling_ply = model.modeling_groups["modeling_group"].modeling_plies["ply"]
 modeling_ply.selection_rules = [LinkedSelectionRule(parallel_rule)]
 
 # %%

--- a/examples/004_advanced_rules.py
+++ b/examples/004_advanced_rules.py
@@ -68,7 +68,7 @@ print(model.unit_system)
 # Add more layers to the modeling ply, so it easier to see the effects of the selection rules.
 # Plot the thickness of all the plies without any rules.
 
-modeling_ply = model.modeling_groups["modeling_group"].plies["ply"]
+modeling_ply = model.modeling_groups["modeling_group"].modeling_plies["ply"]
 modeling_ply.number_of_layers = 10
 
 model.update()

--- a/examples/005_thickness_definitions.py
+++ b/examples/005_thickness_definitions.py
@@ -54,7 +54,7 @@ print(model.unit_system)
 
 
 # Plot the nominal ply thickness.
-modeling_ply = model.modeling_groups["modeling_group"].plies["ply"]
+modeling_ply = model.modeling_groups["modeling_group"].modeling_plies["ply"]
 model.update()
 assert model.elemental_data.thickness is not None
 model.elemental_data.thickness.get_pyvista_mesh(mesh=model.mesh).plot(show_edges=True)

--- a/examples/solve_class40.py
+++ b/examples/solve_class40.py
@@ -225,16 +225,16 @@ for angle in angles:
 # %%
 # Inspect the number of modeling groups and plies
 print(len(model.modeling_groups))
-print(len(model.modeling_groups["hull"].plies))
-print(len(model.modeling_groups["deck"].plies))
-print(len(model.modeling_groups["bulkhead"].plies))
-print(len(model.modeling_groups["keeltower"].plies))
+print(len(model.modeling_groups["hull"].modeling_plies))
+print(len(model.modeling_groups["deck"].modeling_plies))
+print(len(model.modeling_groups["bulkhead"].modeling_plies))
+print(len(model.modeling_groups["keeltower"].modeling_plies))
 
 
 # %%
 # Show the thickness of one of the plies
 model.update()
-modeling_ply = model.modeling_groups["deck"].plies["eglass_ud_02mm_0.5"]
+modeling_ply = model.modeling_groups["deck"].modeling_plies["eglass_ud_02mm_0.5"]
 thickness = modeling_ply.elemental_data.thickness
 assert thickness is not None
 thickness.get_pyvista_mesh(mesh=model.mesh).plot()

--- a/src/ansys/acp/core/_model_printer.py
+++ b/src/ansys/acp/core/_model_printer.py
@@ -110,12 +110,12 @@ def get_model_tree(model: Model) -> Node:
     for modeling_group_name, modeling_group in model.modeling_groups.items():
         group_node = Node(modeling_group_name)
         modeling_groups.children.append(group_node)
-        for ply_name, modeling_ply in modeling_group.plies.items():
-            ply_node = Node(ply_name)
-            group_node.children.append(ply_node)
+        for modeling_ply_name, modeling_ply in modeling_group.modeling_plies.items():
+            modeling_ply_node = Node(modeling_ply_name)
+            group_node.children.append(modeling_ply_node)
             for production_ply_name, production_ply in modeling_ply.production_plies.items():
                 production_ply_node = Node(production_ply_name)
-                ply_node.children.append(production_ply_node)
+                modeling_ply_node.children.append(production_ply_node)
                 for analysis_ply_name, analysis_ply in production_ply.analysis_plies.items():
                     analysis_ply_node = Node(analysis_ply_name)
                     production_ply_node.children.append(analysis_ply_node)

--- a/src/ansys/acp/core/_tree_objects/modeling_group.py
+++ b/src/ansys/acp/core/_tree_objects/modeling_group.py
@@ -62,7 +62,7 @@ class ModelingGroup(CreatableTreeObject, IdTreeObject):
         parent_class_name="ModelingGroup",
         module_name=__module__,
     )
-    plies = define_mutable_mapping(ModelingPly, modeling_ply_pb2_grpc.ObjectServiceStub)
+    modeling_plies = define_mutable_mapping(ModelingPly, modeling_ply_pb2_grpc.ObjectServiceStub)
 
     elemental_data = elemental_data_property(ModelingGroupElementalData)
     nodal_data = nodal_data_property(ModelingGroupNodalData)

--- a/tests/unittests/test_analysis_ply.py
+++ b/tests/unittests/test_analysis_ply.py
@@ -12,7 +12,7 @@ def model(load_model_from_tempfile):
 
 
 def get_first_modeling_ply(parent_model: Model):
-    return parent_model.modeling_groups["ModelingGroup.1"].plies["ModelingPly.1"]
+    return parent_model.modeling_groups["ModelingGroup.1"].modeling_plies["ModelingPly.1"]
 
 
 def get_first_production_ply(parent_model: Model):

--- a/tests/unittests/test_modeling_ply.py
+++ b/tests/unittests/test_modeling_ply.py
@@ -41,7 +41,7 @@ def tree_object(parent_object):
 
 
 class TestModelingPly(NoLockedMixin, TreeObjectTester):
-    COLLECTION_NAME = "plies"
+    COLLECTION_NAME = "modeling_plies"
 
     @staticmethod
     @pytest.fixture
@@ -207,7 +207,7 @@ def minimal_complete_model(load_model_from_tempfile):
 
 @pytest.fixture
 def simple_modeling_ply(minimal_complete_model):
-    return minimal_complete_model.modeling_groups["ModelingGroup.1"].plies["ModelingPly.1"]
+    return minimal_complete_model.modeling_groups["ModelingGroup.1"].modeling_plies["ModelingPly.1"]
 
 
 def test_elemental_data(simple_modeling_ply):

--- a/tests/unittests/test_object_permanence.py
+++ b/tests/unittests/test_object_permanence.py
@@ -47,7 +47,7 @@ def test_unstored():
 
 def test_mapping_identity(model):
     """Check that Mapping objects have the same ID when accessed twice."""
-    modeling_ply = list(list(model.modeling_groups.values())[0].plies.values())[0]
+    modeling_ply = list(list(model.modeling_groups.values())[0].modeling_plies.values())[0]
     production_ply_mapping_1 = modeling_ply.production_plies
     production_ply_mapping_2 = modeling_ply.production_plies
     assert isinstance(production_ply_mapping_1, Mapping)
@@ -74,7 +74,7 @@ def test_linked_object_list_identity(model):
 
 def test_edge_property_list_identity(model):
     """Check that EdgePropertyList objects have the same ID when accessed twice."""
-    modeling_ply = list(list(model.modeling_groups.values())[0].plies.values())[0]
+    modeling_ply = list(list(model.modeling_groups.values())[0].modeling_plies.values())[0]
     selection_rules_1 = modeling_ply.selection_rules
     selection_rules_2 = modeling_ply.selection_rules
     assert isinstance(selection_rules_1, EdgePropertyList)

--- a/tests/unittests/test_plot_utils.py
+++ b/tests/unittests/test_plot_utils.py
@@ -4,7 +4,7 @@ from ansys.acp.core._utils.visualization import _replace_underscores_and_capital
 
 def test_direction_plotter(acp_instance, load_model_from_tempfile):
     with load_model_from_tempfile() as model:
-        modeling_ply = model.modeling_groups["ModelingGroup.1"].plies["ModelingPly.1"]
+        modeling_ply = model.modeling_groups["ModelingGroup.1"].modeling_plies["ModelingPly.1"]
         analysis_ply = modeling_ply.production_plies["ProductionPly"].analysis_plies[
             "P1L1__ModelingPly.1"
         ]

--- a/tests/unittests/test_production_ply.py
+++ b/tests/unittests/test_production_ply.py
@@ -13,7 +13,7 @@ def parent_model(load_model_from_tempfile):
 
 @pytest.fixture
 def parent_object(parent_model):
-    return parent_model.modeling_groups["ModelingGroup.1"].plies["ModelingPly.1"]
+    return parent_model.modeling_groups["ModelingGroup.1"].modeling_plies["ModelingPly.1"]
 
 
 class TestProductionPly(TreeObjectTesterReadOnly):

--- a/type_checks/plots.py
+++ b/type_checks/plots.py
@@ -8,7 +8,7 @@ from ansys.acp.core._tree_objects.modeling_ply import ModelingPlyElementalData
 
 model = Model()
 
-modeling_ply = model.modeling_groups["key"].plies["key"]
+modeling_ply = model.modeling_groups["key"].modeling_plies["key"]
 assert_type(modeling_ply.elemental_data, ModelingPlyElementalData)
 assert_type(modeling_ply.elemental_data.normal, Optional[VectorData])
 assert_type(modeling_ply.elemental_data.thickness, Optional[ScalarData[np.float64]])


### PR DESCRIPTION
Revert the rename of 'modeling_plies' to 'plies'. This change was originally made to accommodate butt joint sequences and interface layers in the collection.
However, the current type of the collection (MutableMapping) is not well-suited to this since it is
- not polymorphic
- not ordered

The current plan is to add MutableMapping exposure also for ``butt_joint_sequences`` and ``interface_layers``, and then add a _different_ collection as ``plies``, which contains all different objects which are to be sorted by global ply number.

This reverts commit 49d68449916c45a39fc6341d602cd3455e050b1a.