### PR TITLE
Make OBJECT_INFO_TYPE and CREATE_REQUEST_TYPE private

### DIFF
--- a/src/ansys/acp/core/_tree_objects/analysis_ply.py
+++ b/src/ansys/acp/core/_tree_objects/analysis_ply.py
@@ -82,7 +82,7 @@ class AnalysisPly(ReadOnlyTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "analysis_plies"
-    OBJECT_INFO_TYPE = analysis_ply_pb2.ObjectInfo
+    _OBJECT_INFO_TYPE = analysis_ply_pb2.ObjectInfo
 
     def _create_stub(self) -> analysis_ply_pb2_grpc.ObjectServiceStub:
         return analysis_ply_pb2_grpc.ObjectServiceStub(self._channel)

--- a/src/ansys/acp/core/_tree_objects/base.py
+++ b/src/ansys/acp/core/_tree_objects/base.py
@@ -43,14 +43,14 @@ class TreeObjectBase(ObjectCacheMixin, GrpcObjectBase):
     __slots__: Iterable[str] = ("_channel_store", "_pb_object")
 
     _COLLECTION_LABEL: str
-    OBJECT_INFO_TYPE: type[ObjectInfo]
+    _OBJECT_INFO_TYPE: type[ObjectInfo]
 
     _pb_object: ObjectInfo
     name: ReadOnlyProperty[str]
 
     def __init__(self: TreeObjectBase, name: str = "") -> None:
         self._channel_store: Channel | None = None
-        self._pb_object: ObjectInfo = self.OBJECT_INFO_TYPE()
+        self._pb_object: ObjectInfo = self._OBJECT_INFO_TYPE()
         # We don't want to invoke gRPC requests for setting the name
         # during object construction, so we set the name directly on
         # the protobuf object.
@@ -72,7 +72,7 @@ class TreeObjectBase(ObjectCacheMixin, GrpcObjectBase):
             used to store the object to another model, where the links
             would be invalid.
         """
-        new_object_info = self.OBJECT_INFO_TYPE()
+        new_object_info = self._OBJECT_INFO_TYPE()
         new_object_info.properties.CopyFrom(self._pb_object.properties)
         if unlink:
             unlink_objects(new_object_info.properties)
@@ -229,7 +229,7 @@ class CreatableTreeObject(TreeObject):
     """Base class for ACP objects which can be created."""
 
     __slots__: Iterable[str] = tuple()
-    CREATE_REQUEST_TYPE: type[CreateRequest]
+    _CREATE_REQUEST_TYPE: type[CreateRequest]
 
     def _get_stub(self) -> CreatableEditableAndReadableResourceStub:
         return cast(CreatableEditableAndReadableResourceStub, super()._get_stub())
@@ -267,7 +267,7 @@ class CreatableTreeObject(TreeObject):
                 + "\n]"
             )
 
-        request = self.CREATE_REQUEST_TYPE(
+        request = self._CREATE_REQUEST_TYPE(
             collection_path=collection_path,
             name=self._pb_object.info.name,
             properties=self._pb_object.properties,

--- a/src/ansys/acp/core/_tree_objects/boolean_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/boolean_selection_rule.py
@@ -67,8 +67,8 @@ class BooleanSelectionRule(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "boolean_selection_rules"
-    OBJECT_INFO_TYPE = boolean_selection_rule_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = boolean_selection_rule_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = boolean_selection_rule_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = boolean_selection_rule_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/cad_component.py
+++ b/src/ansys/acp/core/_tree_objects/cad_component.py
@@ -26,7 +26,7 @@ class CADComponent(ReadOnlyTreeObject, IdTreeObject):
 
     __slots__: Iterable[str] = tuple()
     _COLLECTION_LABEL = "cad_components"
-    OBJECT_INFO_TYPE = cad_component_pb2.ObjectInfo
+    _OBJECT_INFO_TYPE = cad_component_pb2.ObjectInfo
 
     def _create_stub(self) -> cad_component_pb2_grpc.ObjectServiceStub:
         return cad_component_pb2_grpc.ObjectServiceStub(self._channel)

--- a/src/ansys/acp/core/_tree_objects/cad_geometry.py
+++ b/src/ansys/acp/core/_tree_objects/cad_geometry.py
@@ -84,8 +84,8 @@ class CADGeometry(CreatableTreeObject, IdTreeObject):
 
     __slots__: Iterable[str] = tuple()
     _COLLECTION_LABEL = "cad_geometries"
-    OBJECT_INFO_TYPE = cad_geometry_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = cad_geometry_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = cad_geometry_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = cad_geometry_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/cutoff_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/cutoff_selection_rule.py
@@ -91,8 +91,8 @@ class CutoffSelectionRule(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "cutoff_selection_rules"
-    OBJECT_INFO_TYPE = cutoff_selection_rule_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = cutoff_selection_rule_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = cutoff_selection_rule_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = cutoff_selection_rule_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/cylindrical_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/cylindrical_selection_rule.py
@@ -79,8 +79,8 @@ class CylindricalSelectionRule(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "cylindrical_selection_rules"
-    OBJECT_INFO_TYPE = cylindrical_selection_rule_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = cylindrical_selection_rule_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = cylindrical_selection_rule_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = cylindrical_selection_rule_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/edge_set.py
+++ b/src/ansys/acp/core/_tree_objects/edge_set.py
@@ -51,8 +51,8 @@ class EdgeSet(CreatableTreeObject, IdTreeObject):
 
     __slots__: Iterable[str] = tuple()
     _COLLECTION_LABEL = "edge_sets"
-    OBJECT_INFO_TYPE = edge_set_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = edge_set_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = edge_set_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = edge_set_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/element_set.py
+++ b/src/ansys/acp/core/_tree_objects/element_set.py
@@ -64,8 +64,8 @@ class ElementSet(CreatableTreeObject, IdTreeObject):
 
     __slots__: Iterable[str] = tuple()
     _COLLECTION_LABEL = "element_sets"
-    OBJECT_INFO_TYPE = element_set_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = element_set_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = element_set_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = element_set_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/fabric.py
+++ b/src/ansys/acp/core/_tree_objects/fabric.py
@@ -62,8 +62,8 @@ class Fabric(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "fabrics"
-    OBJECT_INFO_TYPE = fabric_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = fabric_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = fabric_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = fabric_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/geometrical_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/geometrical_selection_rule.py
@@ -87,8 +87,8 @@ class GeometricalSelectionRule(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "geometrical_selection_rules"
-    OBJECT_INFO_TYPE = geometrical_selection_rule_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = geometrical_selection_rule_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = geometrical_selection_rule_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = geometrical_selection_rule_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/lookup_table_1d.py
+++ b/src/ansys/acp/core/_tree_objects/lookup_table_1d.py
@@ -54,8 +54,8 @@ class LookUpTable1D(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "lookup_tables_1d"
-    OBJECT_INFO_TYPE = lookup_table_1d_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = lookup_table_1d_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = lookup_table_1d_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = lookup_table_1d_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/lookup_table_1d_column.py
+++ b/src/ansys/acp/core/_tree_objects/lookup_table_1d_column.py
@@ -38,8 +38,8 @@ class LookUpTable1DColumn(LookUpTableColumnBase):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "lookup_table_1d_columns"
-    OBJECT_INFO_TYPE = lookup_table_1d_column_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = lookup_table_1d_column_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = lookup_table_1d_column_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = lookup_table_1d_column_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/lookup_table_3d.py
+++ b/src/ansys/acp/core/_tree_objects/lookup_table_3d.py
@@ -63,8 +63,8 @@ class LookUpTable3D(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "lookup_tables_3d"
-    OBJECT_INFO_TYPE = lookup_table_3d_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = lookup_table_3d_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = lookup_table_3d_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = lookup_table_3d_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/lookup_table_3d_column.py
+++ b/src/ansys/acp/core/_tree_objects/lookup_table_3d_column.py
@@ -38,8 +38,8 @@ class LookUpTable3DColumn(LookUpTableColumnBase):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "lookup_table_3d_columns"
-    OBJECT_INFO_TYPE = lookup_table_3d_column_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = lookup_table_3d_column_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = lookup_table_3d_column_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = lookup_table_3d_column_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/material/material.py
+++ b/src/ansys/acp/core/_tree_objects/material/material.py
@@ -104,8 +104,8 @@ class Material(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "materials"
-    OBJECT_INFO_TYPE = material_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = material_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = material_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = material_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/model.py
+++ b/src/ansys/acp/core/_tree_objects/model.py
@@ -181,7 +181,7 @@ class Model(TreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "models"
-    OBJECT_INFO_TYPE = model_pb2.ObjectInfo
+    _OBJECT_INFO_TYPE = model_pb2.ObjectInfo
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/modeling_group.py
+++ b/src/ansys/acp/core/_tree_objects/modeling_group.py
@@ -47,8 +47,8 @@ class ModelingGroup(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "modeling_groups"
-    OBJECT_INFO_TYPE = modeling_group_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = modeling_group_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = modeling_group_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = modeling_group_pb2.CreateRequest
 
     def __init__(self, *, name: str = "ModelingGroup"):
         super().__init__(name=name)

--- a/src/ansys/acp/core/_tree_objects/modeling_ply.py
+++ b/src/ansys/acp/core/_tree_objects/modeling_ply.py
@@ -268,8 +268,8 @@ class ModelingPly(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "modeling_plies"
-    OBJECT_INFO_TYPE = modeling_ply_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = modeling_ply_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = modeling_ply_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = modeling_ply_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/oriented_selection_set.py
+++ b/src/ansys/acp/core/_tree_objects/oriented_selection_set.py
@@ -131,8 +131,8 @@ class OrientedSelectionSet(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "oriented_selection_sets"
-    OBJECT_INFO_TYPE = oriented_selection_set_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = oriented_selection_set_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = oriented_selection_set_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = oriented_selection_set_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/parallel_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/parallel_selection_rule.py
@@ -81,8 +81,8 @@ class ParallelSelectionRule(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "parallel_selection_rules"
-    OBJECT_INFO_TYPE = parallel_selection_rule_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = parallel_selection_rule_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = parallel_selection_rule_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = parallel_selection_rule_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/production_ply.py
+++ b/src/ansys/acp/core/_tree_objects/production_ply.py
@@ -81,7 +81,7 @@ class ProductionPly(ReadOnlyTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "production_plies"
-    OBJECT_INFO_TYPE = production_ply_pb2.ObjectInfo
+    _OBJECT_INFO_TYPE = production_ply_pb2.ObjectInfo
 
     def _create_stub(self) -> production_ply_pb2_grpc.ObjectServiceStub:
         return production_ply_pb2_grpc.ObjectServiceStub(self._channel)

--- a/src/ansys/acp/core/_tree_objects/rosette.py
+++ b/src/ansys/acp/core/_tree_objects/rosette.py
@@ -38,8 +38,8 @@ class Rosette(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "rosettes"
-    OBJECT_INFO_TYPE = rosette_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = rosette_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = rosette_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = rosette_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/sensor.py
+++ b/src/ansys/acp/core/_tree_objects/sensor.py
@@ -52,8 +52,8 @@ class Sensor(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "sensors"
-    OBJECT_INFO_TYPE = sensor_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = sensor_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = sensor_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = sensor_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/spherical_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/spherical_selection_rule.py
@@ -77,8 +77,8 @@ class SphericalSelectionRule(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "spherical_selection_rules"
-    OBJECT_INFO_TYPE = spherical_selection_rule_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = spherical_selection_rule_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = spherical_selection_rule_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = spherical_selection_rule_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/stackup.py
+++ b/src/ansys/acp/core/_tree_objects/stackup.py
@@ -153,8 +153,8 @@ class Stackup(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "stackups"
-    OBJECT_INFO_TYPE = stackup_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = stackup_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = stackup_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = stackup_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/sublaminate.py
+++ b/src/ansys/acp/core/_tree_objects/sublaminate.py
@@ -142,8 +142,8 @@ class SubLaminate(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "sublaminates"
-    OBJECT_INFO_TYPE = sublaminate_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = sublaminate_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = sublaminate_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = sublaminate_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/tube_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/tube_selection_rule.py
@@ -85,8 +85,8 @@ class TubeSelectionRule(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "tube_selection_rules"
-    OBJECT_INFO_TYPE = tube_selection_rule_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = tube_selection_rule_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = tube_selection_rule_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = tube_selection_rule_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/variable_offset_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/variable_offset_selection_rule.py
@@ -92,8 +92,8 @@ class VariableOffsetSelectionRule(CreatableTreeObject, IdTreeObject):
     __slots__: Iterable[str] = tuple()
 
     _COLLECTION_LABEL = "variable_offset_selection_rules"
-    OBJECT_INFO_TYPE = variable_offset_selection_rule_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = variable_offset_selection_rule_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = variable_offset_selection_rule_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = variable_offset_selection_rule_pb2.CreateRequest
 
     def __init__(
         self,

--- a/src/ansys/acp/core/_tree_objects/virtual_geometry.py
+++ b/src/ansys/acp/core/_tree_objects/virtual_geometry.py
@@ -115,8 +115,8 @@ class VirtualGeometry(CreatableTreeObject, IdTreeObject):
 
     __slots__: Iterable[str] = tuple()
     _COLLECTION_LABEL = "virtual_geometries"
-    OBJECT_INFO_TYPE = virtual_geometry_pb2.ObjectInfo
-    CREATE_REQUEST_TYPE = virtual_geometry_pb2.CreateRequest
+    _OBJECT_INFO_TYPE = virtual_geometry_pb2.ObjectInfo
+    _CREATE_REQUEST_TYPE = virtual_geometry_pb2.CreateRequest
 
     def __init__(
         self,


### PR DESCRIPTION
Make the OBJECT_INFO_TYPE and CREATE_REQUEST_TYPE class attributes private by prefixing them with an underscore.

Closes #453 