### PR TITLE
Remove 'xfail' for tests of 3d lookup table columns set as empty list

### DIFF
--- a/tests/unittests/test_lookup_table_column.py
+++ b/tests/unittests/test_lookup_table_column.py
@@ -10,7 +10,12 @@ from ansys.acp.core import (
     LookUpTableColumnValueType,
 )
 
-from .common.tree_object_tester import ObjectPropertiesToTest, TreeObjectTester, WithLockedMixin
+from .common.tree_object_tester import (
+    ObjectPropertiesToTest,
+    PropertyWithConversion,
+    TreeObjectTester,
+    WithLockedMixin,
+)
 
 
 @pytest.fixture
@@ -56,7 +61,7 @@ def column_data(num_points, column_value_type, request):
         res = np.random.rand(num_points, 3)
     if request.param:
         if num_points == 0 and column_value_type == LookUpTableColumnValueType.DIRECTION:
-            pytest.xfail("Passing empty lists as directional data is not yet supported.")
+            return PropertyWithConversion(res.tolist(), np.zeros(shape=(0, 3)))
         return res.tolist()
     return res
 


### PR DESCRIPTION
Since the backend now supports setting empty lookup table columns
of directional type with an incorrect shape (0,), the corresponding
tests can now succeed.
Add a dataclass PropertyWithConversion to indicate to the test
suite that a given property has a different value after being set.