### PR TITLE
Use docker compose by default, fallback to docker-compose

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -334,7 +334,7 @@ jobs:
 
       - name: Launch MAPDL and DPF servers via docker-compose
         run: |
-          docker-compose -f ./docker-compose/docker-compose-extras.yaml up -d
+          docker compose -f ./docker-compose/docker-compose-extras.yaml up -d
         env:
           ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
           ANSYS_DPF_ACCEPT_LA: "Y"
@@ -354,7 +354,7 @@ jobs:
 
       - name: Stop and clean up MAPDL and DPF servers
         run: |
-          docker-compose -f ./docker-compose/docker-compose-extras.yaml down -v
+          docker compose -f ./docker-compose/docker-compose-extras.yaml down -v
 
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v4
@@ -370,9 +370,9 @@ jobs:
           sudo apt install build-essential zip pandoc texlive-latex-extra latexmk texlive-pstricks
         if: ${{ matrix.build_type == 'full' }}
 
-      - name: Restart MAPDL and DPF servers via docker-compose
+      - name: Restart MAPDL and DPF servers via docker compose
         run: |
-          docker-compose -f ./docker-compose/docker-compose-extras.yaml up -d
+          docker compose -f ./docker-compose/docker-compose-extras.yaml up -d
         env:
           ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
           ANSYS_DPF_ACCEPT_LA: "Y"

--- a/src/ansys/acp/core/_server/docker_compose.py
+++ b/src/ansys/acp/core/_server/docker_compose.py
@@ -62,7 +62,7 @@ _COMPOSE_FILE_DEFAULT_KEY = "default"
 
 @dataclasses.dataclass
 class DockerComposeLaunchConfig:
-    """Configuration options for launching ACP through docker-compose."""
+    """Configuration options for launching ACP through docker compose."""
 
     image_name_pyacp: str = dataclasses.field(
         default="ghcr.io/ansys/acp:latest",
@@ -83,7 +83,7 @@ class DockerComposeLaunchConfig:
     )
     keep_volume: bool = dataclasses.field(
         default=False,
-        metadata={METADATA_KEY_DOC: "If true, keep the volume after docker-compose is stopped."},
+        metadata={METADATA_KEY_DOC: "If true, keep the volume after docker compose is stopped."},
     )
     compose_file: Optional[str] = dataclasses.field(
         default=None,
@@ -99,7 +99,7 @@ class DockerComposeLaunchConfig:
         default_factory=dict,
         metadata={
             METADATA_KEY_DOC: (
-                "Additional environment variables passed to docker-compose. These take "
+                "Additional environment variables passed to docker compose. These take "
                 "precedence over environment variables defined through another configuration "
                 "option (for example 'license_server' which defines 'ANSYSLMD_LICENSE_FILE') "
                 "or the pre-existing environment variables."
@@ -138,11 +138,21 @@ class DockerComposeLauncher(LauncherProtocol[DockerComposeLaunchConfig]):
         else:
             self._compose_file = None
 
-        self._compose_version = parse_version(
-            subprocess.check_output(["docker-compose", "version", "--short"], text=True).replace(
-                "-", "+"
+        try:
+            self._compose_version = parse_version(
+                subprocess.check_output(
+                    ["docker", "compose", "version", "--short"], text=True
+                ).replace("-", "+")
             )
-        )
+            self._compose_cmds = ["docker", "compose"]
+        except subprocess.CalledProcessError:
+            # If 'docker compose does not work, try 'docker-compose' instead.
+            self._compose_version = parse_version(
+                subprocess.check_output(
+                    ["docker-compose", "version", "--short"], text=True
+                ).replace("-", "+")
+            )
+            self._compose_cmds = ["docker-compose"]
 
     @contextlib.contextmanager
     def _get_compose_file(self) -> Iterator[pathlib.Path]:
@@ -165,10 +175,9 @@ class DockerComposeLauncher(LauncherProtocol[DockerComposeLaunchConfig]):
             )
 
             # The compose_file may be temporary, in particular if the package is a zipfile.
-            # To avoid it being deleted before docker-compose has read it, we use the '--wait'
-            # flag for 'docker-compose'.
-            cmd = [
-                "docker-compose",
+            # To avoid it being deleted before docker compose has read it, we use the '--wait'
+            # flag for 'docker compose'.
+            cmd = self._compose_cmds + [
                 "-f",
                 str(compose_file.resolve()),
                 "--project-name",
@@ -177,7 +186,7 @@ class DockerComposeLauncher(LauncherProtocol[DockerComposeLaunchConfig]):
                 "--detach",
             ]
             if self._compose_version >= parse_version("2.1.1"):
-                # The '--wait' flag is only available from version >= 2.1.1 of docker-compose:
+                # The '--wait' flag is only available from version >= 2.1.1 of docker compose:
                 # https://github.com/docker/compose/commit/72e4519cbfb6cdfc600e6ebfa377ce4b8e162c78
                 cmd.append("--wait")
             subprocess.check_call(
@@ -188,8 +197,7 @@ class DockerComposeLauncher(LauncherProtocol[DockerComposeLaunchConfig]):
         # The compose file needs to be passed for all commands with docker-compose 1.X.
         # With docker-compose 2.X, this no longer seems to be necessary.
         with self._get_compose_file() as compose_file:
-            cmd = [
-                "docker-compose",
+            cmd = self._compose_cmds + [
                 "-f",
                 str(compose_file),
                 "--project-name",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,7 +174,7 @@ def _configure_launcher(request: pytest.FixtureRequest) -> None:
         )
 
     else:
-        # If no binary is provided, use docker-compose for running
+        # If no binary is provided, use docker compose for running
         # the ACP server.
         image_name = request.config.getoption(DOCKER_IMAGENAME_OPTION_KEY)
         image_name_filetransfer = "ghcr.io/ansys/tools-filetransfer:latest"


### PR DESCRIPTION
The `docker-compose` command is deprecated according to https://docs.docker.com/compose/faq/, 
and replaced by using a subcommand `docker compose`.

This PR adds `docker compose` as a default in the launching code, and only falls back to `docker-compose`
if calling `docker compose` fails.

In the CI code, use `docker compose` consistently.

