### PR TITLE
Remove workaround for sphinx cache warning

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,7 +18,6 @@ from ansys_sphinx_theme import (
     pyansys_logo_black,
     watermark,
 )
-from sphinx_gallery.sorting import FileNameSortKey
 
 from ansys.acp.core import __version__
 
@@ -141,12 +140,6 @@ nitpick_ignore_regex = [
     ("py:class", r"ansys\.acp.core\..*\.ScalarDataT"),
 ]
 
-# The 'sphinx_gallery_conf' configuration value is not picklable, which makes
-# the configuration cache fail.
-# It should be possible to remove this when https://github.com/sphinx-gallery/sphinx-gallery/issues/1286
-# is resolved.
-suppress_warnings = ["config.cache"]
-
 # sphinx_autodoc_typehints configuration
 typehints_defaults = "comma"
 simplify_optional_unions = True
@@ -192,7 +185,7 @@ sphinx_gallery_conf = {
     # Remove the "Download all examples" button from the top level gallery
     "download_all_examples": False,
     # Sort gallery example by filename instead of number of lines (default)
-    "within_subsection_order": FileNameSortKey,
+    "within_subsection_order": "FileNameSortKey",
     # directory where function granular galleries are stored
     "backreferences_dir": None,
     # Modules for which function level galleries are created.  In


### PR DESCRIPTION
Remove the suppression of the sphinx 'config.cache' warning, by using the string representation of the sphinx-gallery 'FileNameSortKey' instead of directly passing the class.

See https://sphinx-gallery.github.io/dev/configuration.html#importing-callables