### PR TITLE
CI: Fix custom API branch install

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -15,13 +15,15 @@ on:
         description: "Branch of the 'ansys-api-acp' repository used during the build."
         required: false
       docker_image_suffix:
-        description: "Suffix of the 'pyacp' docker image used for testing. For example, ':latest', or '@sha256:<hash>' (without quotes)."
+        description: "Suffix of the 'acp' docker image used for testing. For example, ':latest', or '@sha256:<hash>' (without quotes)."
         required: false
 
 env:
   MAIN_PYTHON_VERSION: "3.12"
   PACKAGE_NAME: "ansys-acp-core"
   DOCUMENTATION_CNAME: "acp.docs.pyansys.com"
+  API_BRANCH: ${{ github.event.inputs.api_branch || '' }}
+  DOCKER_IMAGE_NAME: "ghcr.io/ansys/acp${{ github.event.inputs.docker_image_suffix || ':latest' }}"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -56,10 +58,22 @@ jobs:
           pip install 'poetry!=1.7.0'
           poetry install --with dev,test
 
-      - name: Install custom API branch if needed
-        if: "${{ github.event.inputs.api_branch != '' }}"
+      - name: Build API package from custom branch
+        if: "${{ env.API_BRANCH != '' }}"
         run: |
-          poetry run pip install --force-reinstall git+https://github.com/ansys/ansys-api-acp.git@${{ github.event.inputs.api_branch }}
+          python3.10 -m venv .api_builder_venv
+          . .api_builder_venv/bin/activate
+          python -m pip install --upgrade pip wheel
+          mkdir .api_package
+          python -m pip wheel --no-deps --wheel-dir .api_package git+https://github.com/ansys/ansys-api-acp.git@${{ env.API_BRANCH }}
+
+      - name: Install custom API branch package
+        if: "${{ env.API_BRANCH != '' }}"
+        # The --no-deps flag is added since this may cause dependency conflicts with
+        # other transitive dependencies. For example, when a newer version of protobuf
+        # is installed.
+        run: |
+          poetry run pip install --no-deps --force-reinstall .api_package/*.whl
 
       - name: Run pre-commit
         run: |
@@ -126,18 +140,21 @@ jobs:
           poetry install --with test
 
       - name: Build API package from custom branch
-        if: "${{ github.event.inputs.api_branch != '' }}"
+        if: "${{ env.API_BRANCH != '' }}"
         run: |
           python3.10 -m venv .api_builder_venv
           . .api_builder_venv/bin/activate
           python -m pip install --upgrade pip wheel
           mkdir .api_package
-          python -m pip wheel --no-deps --wheel-dir .api_package git+https://github.com/ansys/ansys-api-acp.git@${{ github.event.inputs.api_branch }}
+          python -m pip wheel --no-deps --wheel-dir .api_package git+https://github.com/ansys/ansys-api-acp.git@${{ env.API_BRANCH }}
 
       - name: Install custom API branch package
-        if: "${{ github.event.inputs.api_branch != '' }}"
+        if: "${{ env.API_BRANCH != '' }}"
+        # The --no-deps flag is added since this may cause dependency conflicts with
+        # other transitive dependencies. For example, when a newer version of protobuf
+        # is installed.
         run: |
-          poetry run pip install --force-reinstall .api_package/*.whl
+          poetry run pip install --no-deps --force-reinstall .api_package/*.whl
 
       - name: Login in Github Container registry
         uses: docker/login-action@v3
@@ -177,7 +194,7 @@ jobs:
           poetry run pytest -v --license-server=1055@$LICENSE_SERVER --no-server-log-files --docker-image=$IMAGE_NAME --build-benchmark-image --benchmark-json benchmark_output.json --benchmark-group-by=fullname ${{ (matrix.python-version == '3.9' && github.ref == 'refs/heads/main') && ' ' || '--validate-benchmarks-only' }}
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
-          IMAGE_NAME: "ghcr.io/ansys/acp${{ github.event.inputs.docker_image_suffix || ':latest' }}"
+          IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
@@ -218,18 +235,21 @@ jobs:
           poetry install --with test,dev
 
       - name: Build API package from custom branch
-        if: "${{ github.event.inputs.api_branch != '' }}"
+        if: "${{ env.API_BRANCH != '' }}"
         run: |
           python3.10 -m venv .api_builder_venv
           . .api_builder_venv/bin/activate
           python -m pip install --upgrade pip wheel
           mkdir .api_package
-          python -m pip wheel --no-deps --wheel-dir .api_package git+https://github.com/ansys/ansys-api-acp.git@${{ github.event.inputs.api_branch }}
+          python -m pip wheel --no-deps --wheel-dir .api_package git+https://github.com/ansys/ansys-api-acp.git@${{ env.API_BRANCH }}
 
       - name: Install custom API branch package
-        if: "${{ github.event.inputs.api_branch != '' }}"
+        if: "${{ env.API_BRANCH != '' }}"
+        # The --no-deps flag is added since this may cause dependency conflicts with
+        # other transitive dependencies. For example, when a newer version of protobuf
+        # is installed.
         run: |
-          poetry run pip install --force-reinstall .api_package/*.whl
+          poetry run pip install --no-deps --force-reinstall .api_package/*.whl
 
       - name: Login in Github Container registry
         uses: docker/login-action@v3
@@ -263,7 +283,7 @@ jobs:
           xvfb-run poetry run make -C doc doctest
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
-          IMAGE_NAME: "ghcr.io/ansys/acp${{ github.event.inputs.docker_image_suffix || ':latest' }}"
+          IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
           PYACP_DOC_SKIP_GALLERY: "true"
           PYACP_DOC_SKIP_API: "true"
 
@@ -310,16 +330,28 @@ jobs:
           pip install 'poetry!=1.7.0'
           poetry install --with dev
 
-      - name: Install custom API branch if needed
-        if: "${{ github.event.inputs.api_branch != '' }}"
+      - name: Build API package from custom branch
+        if: "${{ env.API_BRANCH != '' }}"
         run: |
-          poetry run pip install --force-reinstall git+https://github.com/ansys/ansys-api-acp.git@${{ github.event.inputs.api_branch }}
+          python3.10 -m venv .api_builder_venv
+          . .api_builder_venv/bin/activate
+          python -m pip install --upgrade pip wheel
+          mkdir .api_package
+          python -m pip wheel --no-deps --wheel-dir .api_package git+https://github.com/ansys/ansys-api-acp.git@${{ env.API_BRANCH }}
+
+      - name: Install custom API branch package
+        if: "${{ env.API_BRANCH != '' }}"
+        # The --no-deps flag is added since this may cause dependency conflicts with
+        # other transitive dependencies. For example, when a newer version of protobuf
+        # is installed.
+        run: |
+          poetry run pip install --no-deps --force-reinstall .api_package/*.whl
 
       - name: Configure Local Product Launcher for ACP
         run: >
           poetry run
           ansys-launcher configure ACP docker_compose
-          --image_name_pyacp=ghcr.io/ansys/acp${{ github.event.inputs.docker_image_suffix || ':latest' }}
+          --image_name_pyacp=${{ env.DOCKER_IMAGE_NAME }}
           --image_name_filetransfer=ghcr.io/ansys/tools-filetransfer:latest
           --license_server=1055@$LICENSE_SERVER
           --keep_volume=False

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.16.0
     hooks:
       - id: pyupgrade
         args: [--py39-plus]
 
   - repo: https://github.com/psf/black
-    rev: "24.3.0" # when changed, also update the version in blacken-docs
+    rev: "24.4.2" # when changed, also update the version in blacken-docs
     hooks:
       - id: black
 
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.16.0
+    rev: 1.18.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==24.3.0]
+        additional_dependencies: [black==24.4.2]
 
   - repo: https://github.com/pycqa/isort
     rev: "5.13.2"
@@ -22,16 +22,16 @@ repos:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: "7.0.0"
+    rev: "7.1.0"
     hooks:
       - id: flake8
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies: ["tomli"] # needed to parse pyproject.toml
-        exclude: '^poetry\.lock$'
+        exclude: '^poetry\.lock|pyproject\.toml$'
 
   - repo: https://github.com/python-poetry/poetry/
     rev: "1.8.0"
@@ -61,7 +61,7 @@ repos:
           ]
 
   - repo: https://github.com/ansys/pre-commit-hooks
-    rev: v0.2.9
+    rev: v0.3.1
     hooks:
     - id: add-license-headers
       args: ["--start_year", "2022"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,13 @@
 MIT License
 
-Copyright (c) 2022 - 2024 ANSYS, Inc. All rights reserved.
+Copyright (c) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.


### PR DESCRIPTION
Fix installing a custom API branch in the CI pipeline:
- build the API repository in a separate step, using Python3.10, since
  newer Python versions are not supported by the necessary `protobuf` version
- install the API package without dependencies, to avoid accidentally installing
  a transitive dependency which is incompatible with some other dependency

Other changes:
- Simplify the pipeline logic by using `env` to process the `workflow_dispatch` inputs.
  This also allows setting a default value in the CI `.yml`, for example for a feature branch.