### PR TITLE
Drop python 3.9 support

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Dropping Python 3.9 support (pyupgrade)
+d099b3b4bb80a3461f7f174a6c2944aa13b10a05

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:
@@ -113,7 +113,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -201,7 +201,7 @@ jobs:
       - name: Benchmarks
         working-directory: tests/benchmarks
         run: |
-          poetry run pytest -v --license-server=1055@$LICENSE_SERVER --no-server-log-files --docker-image=$IMAGE_NAME --build-benchmark-image --benchmark-json benchmark_output.json --benchmark-group-by=fullname ${{ (matrix.python-version == '3.9' && github.ref == 'refs/heads/main') && ' ' || '--validate-benchmarks-only' }}
+          poetry run pytest -v --license-server=1055@$LICENSE_SERVER --no-server-log-files --docker-image=$IMAGE_NAME --build-benchmark-image --benchmark-json benchmark_output.json --benchmark-group-by=fullname ${{ (matrix.python-version == '3.10' && github.ref == 'refs/heads/main') && ' ' || '--validate-benchmarks-only' }}
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
           IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
     timeout-minutes: 30
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.16.0
+    rev: v3.17.0
     hooks:
       - id: pyupgrade
         args: [--py310-plus]
 
   - repo: https://github.com/psf/black
-    rev: "24.4.2" # when changed, also update the version in blacken-docs
+    rev: "24.8.0" # when changed, also update the version in blacken-docs
     hooks:
       - id: black
 
@@ -14,7 +14,7 @@ repos:
     rev: 1.18.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==24.4.2]
+        additional_dependencies: [black==24.8.0]
 
   - repo: https://github.com/pycqa/isort
     rev: "5.13.2"
@@ -22,7 +22,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: "7.1.0"
+    rev: "7.1.1"
     hooks:
       - id: flake8
 
@@ -61,7 +61,7 @@ repos:
           ]
 
   - repo: https://github.com/ansys/pre-commit-hooks
-    rev: v0.3.1
+    rev: v0.4.3
     hooks:
     - id: add-license-headers
       args: ["--start_year", "2022"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.16.0
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
 
   - repo: https://github.com/psf/black
     rev: "24.4.2" # when changed, also update the version in blacken-docs

--- a/poetry.lock
+++ b/poetry.lock
@@ -157,13 +157,13 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "alabaster"
-version = "0.7.16"
+version = "1.0.0"
 description = "A light, configurable Sphinx theme"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92"},
-    {file = "alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65"},
+    {file = "alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b"},
+    {file = "alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e"},
 ]
 
 [[package]]
@@ -1899,28 +1899,6 @@ test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "p
 type = ["pytest-mypy"]
 
 [[package]]
-name = "importlib-resources"
-version = "6.4.5"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-6.4.5-py3-none-any.whl", hash = "sha256:ac29d5f956f01d5e4bb63102a5a19957f1b9175e45649977264a1416783bb717"},
-    {file = "importlib_resources-6.4.5.tar.gz", hash = "sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1966,13 +1944,13 @@ test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0)", "pytest-asyncio 
 
 [[package]]
 name = "ipython"
-version = "8.18.1"
+version = "8.27.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "ipython-8.18.1-py3-none-any.whl", hash = "sha256:e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397"},
-    {file = "ipython-8.18.1.tar.gz", hash = "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27"},
+    {file = "ipython-8.27.0-py3-none-any.whl", hash = "sha256:f68b3cb8bde357a5d7adc9598d57e22a45dfbea19eb6b98286fa3b288c9cd55c"},
+    {file = "ipython-8.27.0.tar.gz", hash = "sha256:0b99a2dc9f15fd68692e898e5568725c6d49c527d36a9fb5960ffbdeaa82ff7e"},
 ]
 
 [package.dependencies]
@@ -1981,25 +1959,26 @@ decorator = "*"
 exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 jedi = ">=0.16"
 matplotlib-inline = "*"
-pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
+pexpect = {version = ">4.3", markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""}
 prompt-toolkit = ">=3.0.41,<3.1.0"
 pygments = ">=2.4.0"
 stack-data = "*"
-traitlets = ">=5"
-typing-extensions = {version = "*", markers = "python_version < \"3.10\""}
+traitlets = ">=5.13.0"
+typing-extensions = {version = ">=4.6", markers = "python_version < \"3.12\""}
 
 [package.extras]
-all = ["black", "curio", "docrepr", "exceptiongroup", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio (<0.22)", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
+all = ["ipython[black,doc,kernel,matplotlib,nbconvert,nbformat,notebook,parallel,qtconsole]", "ipython[test,test-extra]"]
 black = ["black"]
-doc = ["docrepr", "exceptiongroup", "ipykernel", "matplotlib", "pickleshare", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio (<0.22)", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "typing-extensions"]
+doc = ["docrepr", "exceptiongroup", "intersphinx-registry", "ipykernel", "ipython[test]", "matplotlib", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "sphinxcontrib-jquery", "tomli", "typing-extensions"]
 kernel = ["ipykernel"]
+matplotlib = ["matplotlib"]
 nbconvert = ["nbconvert"]
 nbformat = ["nbformat"]
 notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
-test = ["pickleshare", "pytest (<7.1)", "pytest-asyncio (<0.22)", "testpath"]
-test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7.1)", "pytest-asyncio (<0.22)", "testpath", "trio"]
+test = ["packaging", "pickleshare", "pytest", "pytest-asyncio (<0.22)", "testpath"]
+test-extra = ["curio", "ipython[test]", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
 
 [[package]]
 name = "ipywidgets"
@@ -2138,7 +2117,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
 jupyter-core = ">=4.12,<5.0.dev0 || >=5.1.dev0"
 python-dateutil = ">=2.8.2"
 pyzmq = ">=23.0"
@@ -2243,7 +2221,6 @@ files = [
 
 [package.dependencies]
 aiohttp = "*"
-importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
 jupyter-server = ">=1.24.0"
 simpervisor = ">=1.0.0"
 tornado = ">=6.1.0"
@@ -2552,7 +2529,6 @@ files = [
 contourpy = ">=1.0.1"
 cycler = ">=0.10"
 fonttools = ">=4.22.0"
-importlib-resources = {version = ">=3.2.0", markers = "python_version < \"3.10\""}
 kiwisolver = ">=1.3.1"
 numpy = ">=1.23"
 packaging = ">=20.0"
@@ -2871,7 +2847,6 @@ files = [
 beautifulsoup4 = "*"
 bleach = "!=5.0.0"
 defusedxml = "*"
-importlib-metadata = {version = ">=3.6", markers = "python_version < \"3.10\""}
 jinja2 = ">=3.0"
 jupyter-core = ">=4.7"
 jupyterlab-pygments = "*"
@@ -3389,18 +3364,18 @@ files = [
 
 [[package]]
 name = "pyansys-tools-versioning"
-version = "0.5.0"
+version = "0.6.0"
 description = "PyAnsys Tools Versioning."
 optional = false
-python-versions = ">=3.9,<4"
+python-versions = "<4,>=3.10"
 files = [
-    {file = "pyansys_tools_versioning-0.5.0-py3-none-any.whl", hash = "sha256:5dcac7272cd70a034ac100094535f1e420951d06f00b9dacf6597366a6f50825"},
-    {file = "pyansys_tools_versioning-0.5.0.tar.gz", hash = "sha256:ed2266f2919a8022ddfd42e3c8d4ccfcaf575b730a09173d2b847eb919489d7f"},
+    {file = "pyansys_tools_versioning-0.6.0-py3-none-any.whl", hash = "sha256:a7191203ccd89ce86a5413e268b3a51127a5b9f5117dba909422bcfdf6e7f81f"},
+    {file = "pyansys_tools_versioning-0.6.0.tar.gz", hash = "sha256:582d430c2325aa5f9fea64abdfb77c14dc5153e814e813d4a37f0f88531e6e41"},
 ]
 
 [package.extras]
-doc = ["Sphinx (==7.2.6)", "Sphinx-copybutton (==0.5.2)", "ansys_sphinx_theme (==0.12.1)", "numpydoc (==1.6.0)", "sphinx-autoapi (==3.0.0)"]
-tests = ["hypothesis (==6.87.1)", "pytest (==7.4.2)", "pytest-cov (==4.1.0)"]
+doc = ["Sphinx (==8.0.2)", "Sphinx-copybutton (==0.5.2)", "ansys_sphinx_theme[autoapi] (==1.0.3)", "numpydoc (==1.8.0)"]
+tests = ["hypothesis (==6.111.0)", "pytest (==8.3.2)", "pytest-cov (==5.0.0)"]
 
 [[package]]
 name = "pyasn1"
@@ -4070,45 +4045,53 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "scipy"
-version = "1.13.1"
+version = "1.14.1"
 description = "Fundamental algorithms for scientific computing in Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "scipy-1.13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:20335853b85e9a49ff7572ab453794298bcf0354d8068c5f6775a0eabf350aca"},
-    {file = "scipy-1.13.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:d605e9c23906d1994f55ace80e0125c587f96c020037ea6aa98d01b4bd2e222f"},
-    {file = "scipy-1.13.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cfa31f1def5c819b19ecc3a8b52d28ffdcc7ed52bb20c9a7589669dd3c250989"},
-    {file = "scipy-1.13.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26264b282b9da0952a024ae34710c2aff7d27480ee91a2e82b7b7073c24722f"},
-    {file = "scipy-1.13.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:eccfa1906eacc02de42d70ef4aecea45415f5be17e72b61bafcfd329bdc52e94"},
-    {file = "scipy-1.13.1-cp310-cp310-win_amd64.whl", hash = "sha256:2831f0dc9c5ea9edd6e51e6e769b655f08ec6db6e2e10f86ef39bd32eb11da54"},
-    {file = "scipy-1.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:27e52b09c0d3a1d5b63e1105f24177e544a222b43611aaf5bc44d4a0979e32f9"},
-    {file = "scipy-1.13.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:54f430b00f0133e2224c3ba42b805bfd0086fe488835effa33fa291561932326"},
-    {file = "scipy-1.13.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e89369d27f9e7b0884ae559a3a956e77c02114cc60a6058b4e5011572eea9299"},
-    {file = "scipy-1.13.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a78b4b3345f1b6f68a763c6e25c0c9a23a9fd0f39f5f3d200efe8feda560a5fa"},
-    {file = "scipy-1.13.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:45484bee6d65633752c490404513b9ef02475b4284c4cfab0ef946def50b3f59"},
-    {file = "scipy-1.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:5713f62f781eebd8d597eb3f88b8bf9274e79eeabf63afb4a737abc6c84ad37b"},
-    {file = "scipy-1.13.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5d72782f39716b2b3509cd7c33cdc08c96f2f4d2b06d51e52fb45a19ca0c86a1"},
-    {file = "scipy-1.13.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:017367484ce5498445aade74b1d5ab377acdc65e27095155e448c88497755a5d"},
-    {file = "scipy-1.13.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:949ae67db5fa78a86e8fa644b9a6b07252f449dcf74247108c50e1d20d2b4627"},
-    {file = "scipy-1.13.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de3ade0e53bc1f21358aa74ff4830235d716211d7d077e340c7349bc3542e884"},
-    {file = "scipy-1.13.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2ac65fb503dad64218c228e2dc2d0a0193f7904747db43014645ae139c8fad16"},
-    {file = "scipy-1.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:cdd7dacfb95fea358916410ec61bbc20440f7860333aee6d882bb8046264e949"},
-    {file = "scipy-1.13.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:436bbb42a94a8aeef855d755ce5a465479c721e9d684de76bf61a62e7c2b81d5"},
-    {file = "scipy-1.13.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8335549ebbca860c52bf3d02f80784e91a004b71b059e3eea9678ba994796a24"},
-    {file = "scipy-1.13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d533654b7d221a6a97304ab63c41c96473ff04459e404b83275b60aa8f4b7004"},
-    {file = "scipy-1.13.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637e98dcf185ba7f8e663e122ebf908c4702420477ae52a04f9908707456ba4d"},
-    {file = "scipy-1.13.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a014c2b3697bde71724244f63de2476925596c24285c7a637364761f8710891c"},
-    {file = "scipy-1.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:392e4ec766654852c25ebad4f64e4e584cf19820b980bc04960bca0b0cd6eaa2"},
-    {file = "scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c"},
+    {file = "scipy-1.14.1-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:b28d2ca4add7ac16ae8bb6632a3c86e4b9e4d52d3e34267f6e1b0c1f8d87e389"},
+    {file = "scipy-1.14.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:d0d2821003174de06b69e58cef2316a6622b60ee613121199cb2852a873f8cf3"},
+    {file = "scipy-1.14.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:8bddf15838ba768bb5f5083c1ea012d64c9a444e16192762bd858f1e126196d0"},
+    {file = "scipy-1.14.1-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:97c5dddd5932bd2a1a31c927ba5e1463a53b87ca96b5c9bdf5dfd6096e27efc3"},
+    {file = "scipy-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ff0a7e01e422c15739ecd64432743cf7aae2b03f3084288f399affcefe5222d"},
+    {file = "scipy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e32dced201274bf96899e6491d9ba3e9a5f6b336708656466ad0522d8528f69"},
+    {file = "scipy-1.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8426251ad1e4ad903a4514712d2fa8fdd5382c978010d1c6f5f37ef286a713ad"},
+    {file = "scipy-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:a49f6ed96f83966f576b33a44257d869756df6cf1ef4934f59dd58b25e0327e5"},
+    {file = "scipy-1.14.1-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:2da0469a4ef0ecd3693761acbdc20f2fdeafb69e6819cc081308cc978153c675"},
+    {file = "scipy-1.14.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:c0ee987efa6737242745f347835da2cc5bb9f1b42996a4d97d5c7ff7928cb6f2"},
+    {file = "scipy-1.14.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3a1b111fac6baec1c1d92f27e76511c9e7218f1695d61b59e05e0fe04dc59617"},
+    {file = "scipy-1.14.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8475230e55549ab3f207bff11ebfc91c805dc3463ef62eda3ccf593254524ce8"},
+    {file = "scipy-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:278266012eb69f4a720827bdd2dc54b2271c97d84255b2faaa8f161a158c3b37"},
+    {file = "scipy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fef8c87f8abfb884dac04e97824b61299880c43f4ce675dd2cbeadd3c9b466d2"},
+    {file = "scipy-1.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b05d43735bb2f07d689f56f7b474788a13ed8adc484a85aa65c0fd931cf9ccd2"},
+    {file = "scipy-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:716e389b694c4bb564b4fc0c51bc84d381735e0d39d3f26ec1af2556ec6aad94"},
+    {file = "scipy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:631f07b3734d34aced009aaf6fedfd0eb3498a97e581c3b1e5f14a04164a456d"},
+    {file = "scipy-1.14.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:af29a935803cc707ab2ed7791c44288a682f9c8107bc00f0eccc4f92c08d6e07"},
+    {file = "scipy-1.14.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2843f2d527d9eebec9a43e6b406fb7266f3af25a751aa91d62ff416f54170bc5"},
+    {file = "scipy-1.14.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:eb58ca0abd96911932f688528977858681a59d61a7ce908ffd355957f7025cfc"},
+    {file = "scipy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30ac8812c1d2aab7131a79ba62933a2a76f582d5dbbc695192453dae67ad6310"},
+    {file = "scipy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f9ea80f2e65bdaa0b7627fb00cbeb2daf163caa015e59b7516395fe3bd1e066"},
+    {file = "scipy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:edaf02b82cd7639db00dbff629995ef185c8df4c3ffa71a5562a595765a06ce1"},
+    {file = "scipy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2ff38e22128e6c03ff73b6bb0f85f897d2362f8c052e3b8ad00532198fbdae3f"},
+    {file = "scipy-1.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1729560c906963fc8389f6aac023739ff3983e727b1a4d87696b7bf108316a79"},
+    {file = "scipy-1.14.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:4079b90df244709e675cdc8b93bfd8a395d59af40b72e339c2287c91860deb8e"},
+    {file = "scipy-1.14.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e0cf28db0f24a38b2a0ca33a85a54852586e43cf6fd876365c86e0657cfe7d73"},
+    {file = "scipy-1.14.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:0c2f95de3b04e26f5f3ad5bb05e74ba7f68b837133a4492414b3afd79dfe540e"},
+    {file = "scipy-1.14.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b99722ea48b7ea25e8e015e8341ae74624f72e5f21fc2abd45f3a93266de4c5d"},
+    {file = "scipy-1.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5149e3fd2d686e42144a093b206aef01932a0059c2a33ddfa67f5f035bdfe13e"},
+    {file = "scipy-1.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e4f5a7c49323533f9103d4dacf4e4f07078f360743dec7f7596949149efeec06"},
+    {file = "scipy-1.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:baff393942b550823bfce952bb62270ee17504d02a1801d7fd0719534dfb9c84"},
+    {file = "scipy-1.14.1.tar.gz", hash = "sha256:5a275584e726026a5699459aa72f828a610821006228e841b94275c4a7c08417"},
 ]
 
 [package.dependencies]
-numpy = ">=1.22.4,<2.3"
+numpy = ">=1.23.5,<2.3"
 
 [package.extras]
-dev = ["cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy", "pycodestyle", "pydevtool", "rich-click", "ruff", "types-psutil", "typing_extensions"]
-doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.12.0)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0)", "sphinx-design (>=0.4.0)"]
-test = ["array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+dev = ["cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy (==1.10.0)", "pycodestyle", "pydevtool", "rich-click", "ruff (>=0.0.292)", "types-psutil", "typing_extensions"]
+doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.13.1)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0,<=7.3.7)", "sphinx-design (>=0.4.0)"]
+test = ["Cython", "array-api-strict (>=2.0)", "asv", "gmpy2", "hypothesis (>=6.30)", "meson", "mpmath", "ninja", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
 name = "scooby"
@@ -4231,22 +4214,21 @@ files = [
 
 [[package]]
 name = "sphinx"
-version = "7.4.7"
+version = "8.0.2"
 description = "Python documentation generator"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "sphinx-7.4.7-py3-none-any.whl", hash = "sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239"},
-    {file = "sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe"},
+    {file = "sphinx-8.0.2-py3-none-any.whl", hash = "sha256:56173572ae6c1b9a38911786e206a110c9749116745873feae4f9ce88e59391d"},
+    {file = "sphinx-8.0.2.tar.gz", hash = "sha256:0cce1ddcc4fd3532cf1dd283bc7d886758362c5c1de6598696579ce96d8ffa5b"},
 ]
 
 [package.dependencies]
-alabaster = ">=0.7.14,<0.8.0"
+alabaster = ">=0.7.14"
 babel = ">=2.13"
 colorama = {version = ">=0.4.6", markers = "sys_platform == \"win32\""}
 docutils = ">=0.20,<0.22"
 imagesize = ">=1.3"
-importlib-metadata = {version = ">=6.0", markers = "python_version < \"3.10\""}
 Jinja2 = ">=3.1"
 packaging = ">=23.0"
 Pygments = ">=2.17"
@@ -4262,27 +4244,27 @@ tomli = {version = ">=2", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["flake8 (>=6.0)", "importlib-metadata (>=6.0)", "mypy (==1.10.1)", "pytest (>=6.0)", "ruff (==0.5.2)", "sphinx-lint (>=0.9)", "tomli (>=2)", "types-docutils (==0.21.0.20240711)", "types-requests (>=2.30.0)"]
+lint = ["flake8 (>=6.0)", "mypy (==1.11.0)", "pytest (>=6.0)", "ruff (==0.5.5)", "sphinx-lint (>=0.9)", "tomli (>=2)", "types-Pillow (==10.2.0.20240520)", "types-Pygments (==2.18.0.20240506)", "types-colorama (==0.4.15.20240311)", "types-defusedxml (==0.7.0.20240218)", "types-docutils (==0.21.0.20240724)", "types-requests (>=2.30.0)"]
 test = ["cython (>=3.0)", "defusedxml (>=0.7.1)", "pytest (>=8.0)", "setuptools (>=70.0)", "typing_extensions (>=4.9)"]
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "2.3.0"
+version = "2.4.1"
 description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "sphinx_autodoc_typehints-2.3.0-py3-none-any.whl", hash = "sha256:3098e2c6d0ba99eacd013eb06861acc9b51c6e595be86ab05c08ee5506ac0c67"},
-    {file = "sphinx_autodoc_typehints-2.3.0.tar.gz", hash = "sha256:535c78ed2d6a1bad393ba9f3dfa2602cf424e2631ee207263e07874c38fde084"},
+    {file = "sphinx_autodoc_typehints-2.4.1-py3-none-any.whl", hash = "sha256:af37abb816ebd2cf56c7a8174fd2f34d0f2f84fbf58265f89429ae107212fe6f"},
+    {file = "sphinx_autodoc_typehints-2.4.1.tar.gz", hash = "sha256:cfe410920cecf08ade046bb387b0007edb83e992de59686c62d194c762f1e45c"},
 ]
 
 [package.dependencies]
-sphinx = ">=7.3.5"
+sphinx = ">=8.0.2"
 
 [package.extras]
-docs = ["furo (>=2024.1.29)"]
+docs = ["furo (>=2024.8.6)"]
 numpy = ["nptyping (>=2.5)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.4.4)", "defusedxml (>=0.7.1)", "diff-cover (>=9)", "pytest (>=8.1.1)", "pytest-cov (>=5)", "sphobjinv (>=2.3.1)", "typing-extensions (>=4.11)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "defusedxml (>=0.7.1)", "diff-cover (>=9.1.1)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "sphobjinv (>=2.3.1.1)", "typing-extensions (>=4.12.2)"]
 
 [[package]]
 name = "sphinx-copybutton"
@@ -5019,5 +5001,5 @@ examples = ["ansys-dpf-composites", "ansys-mapdl-core", "ansys-mechanical-core",
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<3.13"
-content-hash = "89f022fb7f373e77f9052f99f0b50b8783774f047fc0e4a86c952bd469c03793"
+python-versions = ">=3.10,<3.13"
+content-hash = "18c93570d47795eefec3cb312ff1cb5d1d89b55d4c1e5d84599dccd6d23d53d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ include = ["src/**/docker-compose.yaml"]
 # Less than critical but helpful
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -33,7 +32,7 @@ Issues = "https://github.com/ansys/pyacp/issues"
 Releases = "https://github.com/ansys/pyacp/releases"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.10,<3.13"
 numpy = ">=1.22"
 grpcio-health-checking = ">=1.43"
 packaging = ">=15.0"
@@ -139,7 +138,7 @@ ignore-words-list = 'ans,uptodate,notuptodate,eyt'
 quiet-level = 3
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src:$MYPY_CONFIG_FILE_DIR/tests"
 disable_error_code = "type-abstract"
 show_error_context = true

--- a/src/ansys/acp/core/_model_printer.py
+++ b/src/ansys/acp/core/_model_printer.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 
 import os
-from typing import Optional
 
 from ._tree_objects.model import Model
 from ._utils.visualization import _replace_underscores_and_capitalize
@@ -40,11 +39,11 @@ class Node:
         Children of the node.
     """
 
-    def __init__(self, label: str, children: Optional[list["Node"]] = None):
+    def __init__(self, label: str, children: list["Node"] | None = None):
         self.label = label
         self.children: list["Node"] = children if children else []
 
-    def __str__(self, level: Optional[int] = 0) -> str:
+    def __str__(self, level: int | None = 0) -> str:
         assert level is not None
         four_spaces = "    "
         ret = four_spaces * level + self.label + os.linesep

--- a/src/ansys/acp/core/_server/direct.py
+++ b/src/ansys/acp/core/_server/direct.py
@@ -23,7 +23,7 @@
 import dataclasses
 import os
 import subprocess
-from typing import Optional, TextIO, Union
+from typing import TextIO
 
 import grpc
 
@@ -48,7 +48,7 @@ def _get_latest_ansys_installation() -> str:
     if not installations:
         raise ValueError("No Ansys installation found.")
 
-    def sort_key(version_nr: int) -> Union[int, float]:
+    def sort_key(version_nr: int) -> int | float:
         # prefer regular over student installs
         if version_nr < 0:
             return abs(version_nr) - 0.5
@@ -117,7 +117,7 @@ class DirectLauncher(LauncherProtocol[DirectLaunchConfig]):
             text=True,
         )
 
-    def stop(self, *, timeout: Optional[float] = None) -> None:
+    def stop(self, *, timeout: float | None = None) -> None:
         self._process.terminate()
         try:
             self._process.wait(timeout=timeout)
@@ -127,7 +127,7 @@ class DirectLauncher(LauncherProtocol[DirectLaunchConfig]):
         self._stdout.close()
         self._stderr.close()
 
-    def check(self, timeout: Optional[float] = None) -> bool:
+    def check(self, timeout: float | None = None) -> bool:
         channel = grpc.insecure_channel(self.urls[ServerKey.MAIN])
         return check_grpc_health(channel=channel, timeout=timeout)
 

--- a/src/ansys/acp/core/_server/docker_compose.py
+++ b/src/ansys/acp/core/_server/docker_compose.py
@@ -30,7 +30,6 @@ import math
 import os
 import pathlib
 import subprocess
-from typing import Optional
 import uuid
 
 import grpc
@@ -85,7 +84,7 @@ class DockerComposeLaunchConfig:
         default=False,
         metadata={METADATA_KEY_DOC: "If true, keep the volume after docker compose is stopped."},
     )
-    compose_file: Optional[str] = dataclasses.field(
+    compose_file: str | None = dataclasses.field(
         default=None,
         metadata={
             METADATA_KEY_DOC: (
@@ -134,7 +133,7 @@ class DockerComposeLauncher(LauncherProtocol[DockerComposeLaunchConfig]):
         self._keep_volume = config.keep_volume
 
         if config.compose_file is not None:
-            self._compose_file: Optional[pathlib.Path] = pathlib.Path(config.compose_file)
+            self._compose_file: pathlib.Path | None = pathlib.Path(config.compose_file)
         else:
             self._compose_file = None
 
@@ -193,7 +192,7 @@ class DockerComposeLauncher(LauncherProtocol[DockerComposeLaunchConfig]):
                 cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
 
-    def stop(self, *, timeout: Optional[float] = None) -> None:
+    def stop(self, *, timeout: float | None = None) -> None:
         # The compose file needs to be passed for all commands with docker-compose 1.X.
         # With docker-compose 2.X, this no longer seems to be necessary.
         with self._get_compose_file() as compose_file:
@@ -211,7 +210,7 @@ class DockerComposeLauncher(LauncherProtocol[DockerComposeLaunchConfig]):
                 cmd.append("--volumes")
             subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-    def check(self, timeout: Optional[float] = None) -> bool:
+    def check(self, timeout: float | None = None) -> bool:
         for url in self.urls.values():
             channel = grpc.insecure_channel(url)
             if not check_grpc_health(channel=channel, timeout=timeout):

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
@@ -22,13 +22,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator, MutableSequence
+from collections.abc import Callable, Iterable, Iterator, MutableSequence
 import sys
 import textwrap
-from typing import Any, Callable, Protocol, TypeVar, cast, overload
+from typing import Any, Concatenate, Protocol, TypeVar, cast, overload
 
 from google.protobuf.message import Message
-from typing_extensions import Concatenate, ParamSpec, Self
+from typing_extensions import ParamSpec, Self
 
 from .._object_cache import ObjectCacheMixin, constructor_with_cache
 from ..base import CreatableTreeObject

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/enum_wrapper.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/enum_wrapper.py
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 __all__ = ["wrap_to_string_enum"]
 
@@ -37,7 +38,7 @@ def wrap_to_string_enum(
     key_converter: Callable[[str], str] = lambda val: val,
     value_converter: Callable[[str], str] = lambda val: val.lower(),
     doc: str,
-    explicit_value_list: Optional[tuple[int, ...]] = None,
+    explicit_value_list: tuple[int, ...] | None = None,
 ) -> tuple[StrEnum, Callable[[StrEnum], int], Callable[[int], StrEnum]]:
     """Create a string Enum with the same keys as the given protobuf Enum.
 

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/linked_object_helpers.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/linked_object_helpers.py
@@ -21,7 +21,6 @@
 # SOFTWARE.
 
 from collections.abc import Iterable
-from typing import Union
 
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.message import Message
@@ -39,7 +38,7 @@ def unlink_objects(pb_object: Message) -> None:
 
 def linked_path_fields(
     pb_object: Message,
-) -> Iterable[tuple[Message, FieldDescriptor, Union[ResourcePath, CollectionPath]]]:
+) -> Iterable[tuple[Message, FieldDescriptor, ResourcePath | CollectionPath]]:
     """Get all linked paths from a protobuf object.
 
     Get tuples (parent_message, field_descriptor, {resource_path or collection_path})

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/linked_object_list.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/linked_object_list.py
@@ -22,10 +22,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator, MutableSequence
+from collections.abc import Callable, Iterable, Iterator, MutableSequence
 from functools import partial
 import sys
-from typing import Any, Callable, TypeVar, cast, overload
+from typing import Any, TypeVar, cast, overload
 
 from grpc import Channel
 import numpy as np

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/mapping.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/mapping.py
@@ -22,11 +22,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import Any, Callable, Generic, TypeVar
+from collections.abc import Callable, Iterator
+from typing import Any, Concatenate, Generic, TypeVar
 
 from grpc import Channel
-from typing_extensions import Concatenate, ParamSpec, Self
+from typing_extensions import ParamSpec, Self
 
 from ansys.api.acp.v0.base_pb2 import CollectionPath, DeleteRequest, ListRequest
 

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/property_helper.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/property_helper.py
@@ -27,8 +27,9 @@ automatically synchronized with the backend via gRPC.
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import reduce
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
 
 from google.protobuf.message import Message
 

--- a/src/ansys/acp/core/_tree_objects/_object_cache.py
+++ b/src/ansys/acp/core/_tree_objects/_object_cache.py
@@ -20,11 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from collections.abc import Iterable
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable, Iterable
+from typing import Any, Concatenate, TypeAlias, TypeVar
 from weakref import WeakValueDictionary
 
-from typing_extensions import Concatenate, ParamSpec, Self, TypeAlias
+from typing_extensions import ParamSpec, Self
 
 __all__ = ["ObjectCacheMixin", "constructor_with_cache"]
 

--- a/src/ansys/acp/core/_tree_objects/base.py
+++ b/src/ansys/acp/core/_tree_objects/base.py
@@ -24,16 +24,16 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from functools import wraps
 import typing
-from typing import Any, Callable, Generic, TypeVar, cast
+from typing import Any, Concatenate, Generic, TypeAlias, TypeVar, cast
 
 from grpc import Channel
 from packaging.version import Version
 from packaging.version import parse as parse_version
-from typing_extensions import Concatenate, ParamSpec, Self, TypeAlias
+from typing_extensions import ParamSpec, Self
 
 from ansys.api.acp.v0.base_pb2 import CollectionPath, DeleteRequest, GetRequest, ResourcePath
 

--- a/src/ansys/acp/core/_tree_objects/linked_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/linked_selection_rule.py
@@ -22,8 +22,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import typing
-from typing import Callable, Union
+from typing import Union
 
 from typing_extensions import Self
 

--- a/src/ansys/acp/core/_tree_objects/modeling_ply.py
+++ b/src/ansys/acp/core/_tree_objects/modeling_ply.py
@@ -22,9 +22,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Container, Iterable
+from collections.abc import Callable, Container, Iterable
 import dataclasses
-from typing import Any, Callable
+from typing import Any
 
 import numpy as np
 from typing_extensions import Self

--- a/src/ansys/acp/core/_tree_objects/stackup.py
+++ b/src/ansys/acp/core/_tree_objects/stackup.py
@@ -22,8 +22,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
-from typing import Any, Callable
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
 
 from ansys.api.acp.v0 import stackup_pb2, stackup_pb2_grpc
 

--- a/src/ansys/acp/core/_tree_objects/sublaminate.py
+++ b/src/ansys/acp/core/_tree_objects/sublaminate.py
@@ -22,9 +22,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 import typing
-from typing import Any, Callable, Union, get_args
+from typing import Any, Union, get_args
 
 from ansys.api.acp.v0 import sublaminate_pb2, sublaminate_pb2_grpc
 

--- a/src/ansys/acp/core/_tree_objects/virtual_geometry.py
+++ b/src/ansys/acp/core/_tree_objects/virtual_geometry.py
@@ -22,9 +22,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 import typing
-from typing import Any, Callable
+from typing import Any
 
 from ansys.api.acp.v0 import base_pb2, virtual_geometry_pb2, virtual_geometry_pb2_grpc
 

--- a/src/ansys/acp/core/_utils/array_conversions.py
+++ b/src/ansys/acp/core/_utils/array_conversions.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from collections.abc import Collection
-from typing import Any, Union, overload
+from typing import Any, overload
 
 import numpy as np
 import numpy.typing as npt
@@ -40,7 +40,7 @@ def to_1D_int_array(data: Collection[int]) -> IntArray:
     return IntArray(shape=[len(data)], data=tuple(data))
 
 
-def to_tuple_from_1D_array(array: Union[IntArray, DoubleArray]) -> tuple[Any, ...]:
+def to_tuple_from_1D_array(array: IntArray | DoubleArray) -> tuple[Any, ...]:
     """Convert a 1D IntArray or DoubleArray protobuf message to a tuple."""
     if not len(array.shape) == 1:
         raise RuntimeError(f"Cannot convert {len(array.shape)}-dimensional array to tuple!")
@@ -66,8 +66,8 @@ def to_numpy(array_pb: DoubleArray) -> npt.NDArray[np.float64]: ...
 
 
 def to_numpy(
-    array_pb: Union[IntArray, Int32Array, DoubleArray]
-) -> Union[npt.NDArray[np.int64], npt.NDArray[np.int32], npt.NDArray[np.float64]]:
+    array_pb: IntArray | Int32Array | DoubleArray,
+) -> npt.NDArray[np.int64] | npt.NDArray[np.int32] | npt.NDArray[np.float64]:
     """Convert a protubuf array message to a numpy array."""
     dtype = {
         IntArray: np.int64,
@@ -79,8 +79,8 @@ def to_numpy(
 
 def dataarray_to_numpy(
     array_pb: DataArray,
-    dtype: Union[type[np.int32], type[np.int64], type[np.float64]],
-) -> Union[npt.NDArray[np.int64], npt.NDArray[np.int32], npt.NDArray[np.float64]]:
+    dtype: type[np.int32] | type[np.int64] | type[np.float64],
+) -> npt.NDArray[np.int64] | npt.NDArray[np.int32] | npt.NDArray[np.float64]:
     """Convert a DataArray protobuf message to a numpy array."""
     data_array_attribute = array_pb.WhichOneof("data")
     if data_array_attribute is None:

--- a/src/ansys/acp/core/_workflow.py
+++ b/src/ansys/acp/core/_workflow.py
@@ -20,11 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from collections.abc import Callable
 import pathlib
 import shutil
 import tempfile
 import typing
-from typing import Any, Callable, Optional, Protocol
+from typing import Any, Protocol
 
 from . import CADGeometry, UnitSystemType
 from ._server.acp_instance import ACP
@@ -41,7 +42,7 @@ __all__ = ["ACPWorkflow", "get_composite_post_processing_files", "get_dpf_unit_s
 
 
 class _LocalWorkingDir:
-    def __init__(self, path: Optional[PATH] = None):
+    def __init__(self, path: PATH | None = None):
         self._user_defined_working_dir = None
         self._temp_working_dir = None
         if path is None:
@@ -165,7 +166,7 @@ class ACPWorkflow:
         self,
         *,
         acp: ACP[ServerProtocol],
-        local_working_directory: Optional[PATH] = None,
+        local_working_directory: PATH | None = None,
         local_file_path: PATH,
         file_format: str,
         **kwargs: Any,
@@ -187,7 +188,7 @@ class ACPWorkflow:
         cls,
         acp: ACP[ServerProtocol],
         acph5_file_path: PATH,
-        local_working_directory: Optional[PATH] = None,
+        local_working_directory: PATH | None = None,
     ) -> "ACPWorkflow":
         """Instantiate an ACP Workflow from an acph5 file.
 
@@ -215,7 +216,7 @@ class ACPWorkflow:
         acp: ACP[ServerProtocol],
         cdb_or_dat_file_path: PATH,
         unit_system: UnitSystemType = UnitSystemType.UNDEFINED,
-        local_working_directory: Optional[PATH] = None,
+        local_working_directory: PATH | None = None,
     ) -> "ACPWorkflow":
         """Instantiate an ACP Workflow from a cdb file.
 

--- a/tests/unittests/common/linked_object_list_tester.py
+++ b/tests/unittests/common/linked_object_list_tester.py
@@ -22,8 +22,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from mypy_extensions import DefaultNamedArg, KwArg

--- a/tests/unittests/common/tree_object_tester.py
+++ b/tests/unittests/common/tree_object_tester.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -47,7 +47,7 @@ class ObjectPropertiesToTest:
     # If create_args exists the create method will use the create_args dictionaries
     # to create the object. The object
     # will be created for each dictionary in the list.
-    create_args: Optional[list[dict[str, Any]]] = None
+    create_args: list[dict[str, Any]] | None = None
 
 
 class TreeObjectTesterReadOnly:

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -20,14 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 __all__ = ["check_property"]
 
 T = TypeVar("T")
 
 
-def check_property(obj: Any, *, name: str, value: T, set_value: Optional[T] = None):
+def check_property(obj: Any, *, name: str, value: T, set_value: T | None = None):
     assert hasattr(obj, name), f"Object '{obj}' has no property named '{name}'"
     assert (
         getattr(obj, name) == value

--- a/tests/unittests/test_material.py
+++ b/tests/unittests/test_material.py
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 import uuid
 
 from hypothesis import HealthCheck, given, settings

--- a/type_checks/add_methods.py
+++ b/type_checks/add_methods.py
@@ -1,4 +1,5 @@
-from typing import Callable, Union
+from collections.abc import Callable
+from typing import Union
 
 from mypy_extensions import Arg, DefaultNamedArg
 from typing_extensions import assert_type

--- a/type_checks/create_methods.py
+++ b/type_checks/create_methods.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from mypy_extensions import DefaultNamedArg
 from typing_extensions import assert_type


### PR DESCRIPTION
Following the PyAnsys Python version support policy, drop support for 3.9.

Update pre-commit hooks using `pre-commit autoupdate`.

Add a `.git-blame-ignore-revs` file to ignore the `pyupgrade` changes.