### PR TITLE
Fix EdgePropertyList construction via _from_object_info

### DIFF
--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
@@ -158,7 +158,11 @@ class EdgePropertyList(ObjectCacheMixin, MutableSequence[ValueT]):
                 self._parent_object, pb_object, self._apply_changes
             )
         )
-        self._object_list_store = self._get_object_list_from_parent()
+        if self._parent_object._is_stored:
+            self._object_list_store = self._get_object_list_from_parent()
+        else:
+            # Cannot instantiate the objects if the server is not available
+            self._object_list_store = []
 
     @property
     def _object_list(self) -> list[ValueT]:

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
@@ -153,13 +153,12 @@ class EdgePropertyList(ObjectCacheMixin, MutableSequence[ValueT]):
         self._attribute_name = _attribute_name
         self._name = _attribute_name.split(".")[-1]
 
-        self._object_list_store = self._get_object_list_from_parent()
-
         self._object_constructor: Callable[[Message], ValueT] = (
             lambda pb_object: _from_pb_constructor(
                 self._parent_object, pb_object, self._apply_changes
             )
         )
+        self._object_list_store = self._get_object_list_from_parent()
 
     @property
     def _object_list(self) -> list[ValueT]:

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
@@ -393,7 +393,13 @@ def define_edge_property_list(
 ) -> Any:
     """Define a list of linked tree objects with link properties."""
 
-    def getter(self: CreatableTreeObject) -> EdgePropertyList[GenericEdgePropertyType]:
+    def getter(
+        self: CreatableTreeObject, *, check_stored: bool = True
+    ) -> EdgePropertyList[GenericEdgePropertyType]:
+        if check_stored and not self._is_stored:
+            raise RuntimeError(
+                f"Cannot access property {attribute_name.split('.')[-1]} on an object that is not stored."
+            )
         return EdgePropertyList._initialize_with_cache(
             parent_object=self,
             object_type=value_type,
@@ -402,7 +408,8 @@ def define_edge_property_list(
         )
 
     def setter(self: CreatableTreeObject, value: list[GenericEdgePropertyType]) -> None:
-        getter(self)[:] = value
+        # allow wholesale replacement on unstored objects
+        getter(self, check_stored=False)[:] = value
 
     return _wrap_doc(_exposed_grpc_property(getter).setter(setter), doc=doc)
 

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/edge_property_list.py
@@ -191,10 +191,6 @@ class EdgePropertyList(ObjectCacheMixin, MutableSequence[ValueT]):
 
     def _set_object_list(self, items: list[ValueT]) -> None:
         """Set the object list on the parent AND updates the internal object list."""
-        # if not self._parent_object._is_stored:
-        #     if items: # accept empty list to allow for default construction
-        #         raise RuntimeError("Cannot set object list before the parent object is stored.")
-        # else:
         pb_obj_list = []
         for item in items:
             if not isinstance(item, self._object_type):

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/polymorphic_from_pb.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/polymorphic_from_pb.py
@@ -22,12 +22,15 @@
 
 from __future__ import annotations
 
+import typing
 from typing import Protocol
 
-import grpc
 from typing_extensions import Self
 
 from ansys.api.acp.v0.base_pb2 import ResourcePath
+
+if typing.TYPE_CHECKING:
+    from ..base import ServerWrapper
 
 __all__ = ["CreatableFromResourcePath", "tree_object_from_resource_path"]
 
@@ -36,12 +39,14 @@ class CreatableFromResourcePath(Protocol):
     """Interface for objects that can be created from a resource path."""
 
     @classmethod
-    def _from_resource_path(cls, resource_path: ResourcePath, channel: grpc.Channel) -> Self: ...
+    def _from_resource_path(
+        cls, resource_path: ResourcePath, server_wrapper: ServerWrapper
+    ) -> Self: ...
 
 
 def tree_object_from_resource_path(
     resource_path: ResourcePath,
-    channel: grpc.Channel,
+    server_wrapper: ServerWrapper,
     allowed_types: tuple[type[CreatableFromResourcePath], ...] | None = None,
 ) -> CreatableFromResourcePath | None:
     """Instantiate a tree object from its resource path.
@@ -50,8 +55,8 @@ def tree_object_from_resource_path(
     ----------
     resource_path :
         Resource path of the object.
-    channel :
-        gRPC channel to the server.
+    server_wrapper :
+        Representation of the ACP server.
     allowed_types :
         Allowed types of the object. If None, all registered types are allowed.
     """
@@ -72,4 +77,4 @@ def tree_object_from_resource_path(
                 f"Resource path {resource_path.value} does not point to a valid "
                 f"object type. Allowed types: {allowed_types}"
             )
-    return resource_class._from_resource_path(resource_path, channel)
+    return resource_class._from_resource_path(resource_path, server_wrapper=server_wrapper)

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/polymorphic_from_pb.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/polymorphic_from_pb.py
@@ -29,7 +29,7 @@ from typing_extensions import Self
 
 from ansys.api.acp.v0.base_pb2 import ResourcePath
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from ..base import ServerWrapper
 
 __all__ = ["CreatableFromResourcePath", "tree_object_from_resource_path"]

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/property_helper.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/property_helper.py
@@ -28,7 +28,6 @@ automatically synchronized with the backend via gRPC.
 from __future__ import annotations
 
 from functools import reduce
-import typing
 from typing import Any, Callable, TypeVar
 
 from google.protobuf.message import Message
@@ -36,7 +35,6 @@ from google.protobuf.message import Message
 from ansys.api.acp.v0.base_pb2 import ResourcePath
 
 from ..._utils.property_protocols import ReadOnlyProperty, ReadWriteProperty
-from ..base import TreeObjectBase
 from .polymorphic_from_pb import CreatableFromResourcePath, tree_object_from_resource_path
 from .protocols import Editable, GrpcObjectBase, ObjectInfo, Readable
 
@@ -132,12 +130,12 @@ def grpc_data_getter(
 
 
 def grpc_linked_object_setter(
-    name: str, to_protobuf: _TO_PROTOBUF_T[TreeObjectBase | None]
-) -> Callable[[Editable, TreeObjectBase | None], None]:
+    name: str, to_protobuf: _TO_PROTOBUF_T[Readable | None]
+) -> Callable[[Editable, Readable | None], None]:
     """Create a setter method which updates the linked object via the gRPC Put endpoint."""
     func = grpc_data_setter(name, to_protobuf)
 
-    def inner(self: Editable, value: TreeObjectBase | None) -> None:
+    def inner(self: Editable, value: Readable | None) -> None:
         if value is not None and not value._is_stored:
             raise Exception("Cannot link to an unstored object.")
         func(self, value)
@@ -301,10 +299,8 @@ def grpc_link_property(
         Types which are allowed to be set on the property. An
         error will be raised if an object of a different type is set.
     """
-    if typing.TYPE_CHECKING:
-        from ..base import TreeObjectBase
 
-    def to_protobuf(obj: TreeObjectBase | None) -> ResourcePath:
+    def to_protobuf(obj: Readable | None) -> ResourcePath:
         if obj is None:
             return ResourcePath(value="")
         if not isinstance(obj, allowed_types):

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/protocols.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/protocols.py
@@ -37,6 +37,7 @@ from ansys.api.acp.v0.base_pb2 import (
     Empty,
     GetRequest,
     ListRequest,
+    ResourcePath,
 )
 
 if typing.TYPE_CHECKING:
@@ -181,6 +182,9 @@ class Readable(Protocol):
 
     @property
     def _server_wrapper(self) -> ServerWrapper: ...
+
+    @property
+    def _resource_path(self) -> ResourcePath: ...
 
     _pb_object: Any
 

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/protocols.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/protocols.py
@@ -40,7 +40,7 @@ from ansys.api.acp.v0.base_pb2 import (
     ResourcePath,
 )
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from ..base import ServerWrapper
 
 

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/protocols.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/protocols.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 import textwrap
+import typing
 from typing import Any, Protocol
 
 from google.protobuf.message import Message
@@ -37,6 +38,9 @@ from ansys.api.acp.v0.base_pb2 import (
     GetRequest,
     ListRequest,
 )
+
+if typing.TYPE_CHECKING:
+    from ..base import ServerWrapper
 
 
 class CreateRequest(Protocol):
@@ -176,7 +180,7 @@ class Readable(Protocol):
     def _is_stored(self) -> bool: ...
 
     @property
-    def _channel(self) -> grpc.Channel: ...
+    def _server_wrapper(self) -> ServerWrapper: ...
 
     _pb_object: Any
 

--- a/src/ansys/acp/core/_tree_objects/_mesh_data.py
+++ b/src/ansys/acp/core/_tree_objects/_mesh_data.py
@@ -44,7 +44,7 @@ from .enums import (
     nodal_data_type_to_pb,
 )
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from .model import MeshData  # avoid circular import
 
 __all__ = [

--- a/src/ansys/acp/core/_tree_objects/base.py
+++ b/src/ansys/acp/core/_tree_objects/base.py
@@ -43,6 +43,7 @@ from .._utils.resource_paths import join as _rp_join
 from .._utils.resource_paths import to_parts
 from ._grpc_helpers.exceptions import wrap_grpc_errors
 from ._grpc_helpers.linked_object_helpers import linked_path_fields, unlink_objects
+from ._grpc_helpers.polymorphic_from_pb import CreatableFromResourcePath
 from ._grpc_helpers.property_helper import (
     _get_data_attribute,
     grpc_data_property,
@@ -482,3 +483,6 @@ if typing.TYPE_CHECKING:
     # Ensure that the TreeObject satisfies the Editable and Readable interfaces
     _y: Editable = typing.cast(TreeObject, None)
     _z: Readable = typing.cast(TreeObject, None)
+
+    # Ensure the TreeObjectBase satisfies the CreatableFromResourcePath interface
+    _a: CreatableFromResourcePath = typing.cast(TreeObjectBase, None)

--- a/src/ansys/acp/core/_tree_objects/base.py
+++ b/src/ansys/acp/core/_tree_objects/base.py
@@ -62,7 +62,7 @@ from ._grpc_helpers.protocols import (
 )
 from ._object_cache import ObjectCacheMixin, constructor_with_cache
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from .._server import ACP
 
 
@@ -477,7 +477,7 @@ def supported_since(version: str) -> Callable[[_WRAPPED_T[T, P, R]], _WRAPPED_T[
     return decorator
 
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     # Ensure that the ReadOnlyTreeObject satisfies the Gettable interface
     _x: Readable = typing.cast(ReadOnlyTreeObject, None)
     # Ensure that the TreeObject satisfies the Editable and Readable interfaces

--- a/src/ansys/acp/core/_tree_objects/base.py
+++ b/src/ansys/acp/core/_tree_objects/base.py
@@ -479,5 +479,6 @@ def supported_since(version: str) -> Callable[[_WRAPPED_T[T, P, R]], _WRAPPED_T[
 if typing.TYPE_CHECKING:
     # Ensure that the ReadOnlyTreeObject satisfies the Gettable interface
     _x: Readable = typing.cast(ReadOnlyTreeObject, None)
-    # Ensure that the TreeObject satisfies the Editable interface
+    # Ensure that the TreeObject satisfies the Editable and Readable interfaces
     _y: Editable = typing.cast(TreeObject, None)
+    _z: Readable = typing.cast(TreeObject, None)

--- a/src/ansys/acp/core/_tree_objects/linked_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/linked_selection_rule.py
@@ -212,7 +212,7 @@ class LinkedSelectionRule(GenericEdgePropertyType):
         allowed_types = tuple(allowed_types_list)
 
         selection_rule = tree_object_from_resource_path(
-            resource_path=message.resource_path, channel=parent_object._channel
+            resource_path=message.resource_path, server_wrapper=parent_object._server_wrapper
         )
         if not isinstance(selection_rule, allowed_types):
             raise TypeError(

--- a/src/ansys/acp/core/_tree_objects/linked_selection_rule.py
+++ b/src/ansys/acp/core/_tree_objects/linked_selection_rule.py
@@ -45,7 +45,7 @@ from .spherical_selection_rule import SphericalSelectionRule
 from .tube_selection_rule import TubeSelectionRule
 from .variable_offset_selection_rule import VariableOffsetSelectionRule
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     # Since the 'LinkedSelectionRule' class is used by the boolean selection rule,
     # this would cause a circular import at run-time.
     from .boolean_selection_rule import BooleanSelectionRule

--- a/src/ansys/acp/core/_tree_objects/oriented_selection_set.py
+++ b/src/ansys/acp/core/_tree_objects/oriented_selection_set.py
@@ -79,7 +79,7 @@ __all__ = [
     "OrientedSelectionSetNodalData",
 ]
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     # Since the 'LinkedSelectionRule' class is used by the boolean selection rule,
     # this would cause a circular import at run-time.
     from .. import BooleanSelectionRule, GeometricalSelectionRule

--- a/src/ansys/acp/core/_tree_objects/sublaminate.py
+++ b/src/ansys/acp/core/_tree_objects/sublaminate.py
@@ -107,7 +107,7 @@ class Lamina(GenericEdgePropertyType):
         apply_changes: Callable[[], None],
     ) -> Lamina:
         material = tree_object_from_resource_path(
-            resource_path=message.material, channel=parent_object._channel
+            resource_path=message.material, server_wrapper=parent_object._server_wrapper
         )
 
         if not isinstance(material, get_args(_LINKABLE_MATERIAL_TYPES)):

--- a/src/ansys/acp/core/_tree_objects/virtual_geometry.py
+++ b/src/ansys/acp/core/_tree_objects/virtual_geometry.py
@@ -39,7 +39,7 @@ from .cad_geometry import CADGeometry
 from .enums import status_type_from_pb, virtual_geometry_dimension_from_pb
 from .object_registry import register
 
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from .cad_component import CADComponent
 
 

--- a/src/ansys/acp/core/_workflow.py
+++ b/src/ansys/acp/core/_workflow.py
@@ -33,7 +33,7 @@ from ._tree_objects import Model
 from ._typing_helper import PATH
 
 # Avoid dependencies on pydpf-composites and dpf-core if it is not used
-if typing.TYPE_CHECKING:
+if typing.TYPE_CHECKING:  # pragma: no cover
     from ansys.dpf.composites.data_sources import ContinuousFiberCompositesFiles
     from ansys.dpf.core import UnitSystem
 

--- a/tests/unittests/test_edge_property_list.py
+++ b/tests/unittests/test_edge_property_list.py
@@ -135,6 +135,28 @@ def test_clone_clear_store(simple_model, simple_sublaminate):
     assert len(sublaminate_clone.materials) == 0
 
 
+def test_clone_assign_store(simple_model, simple_sublaminate):
+    """Check that the edge property list can be changed on a cloned object."""
+    model = simple_model
+    # GIVEN: a model with a sublaminate which has two materials
+    sublaminate = simple_sublaminate
+
+    # WHEN: cloning the sublaminate, setting new materials, then storing the clone
+    sublaminate_clone = sublaminate.clone()
+    import gc
+
+    gc.collect()
+    fabric = simple_model.create_fabric(name="new_fabric", material=simple_model.create_material())
+    new_materials = [Lamina(material=fabric, angle=3.0)]
+    sublaminate_clone.materials = new_materials
+    sublaminate_clone.store(parent=model)
+
+    # THEN: the clone is stored and has no materials
+    assert len(sublaminate_clone.materials) == 1
+    assert sublaminate_clone.materials[0].material.name == "new_fabric"
+    assert sublaminate_clone.materials[0].angle == 3.0
+
+
 def test_store_with_entries(simple_model, check_simple_sublaminate):
     """Check that a sublaminate can be created with materials, and then stored."""
     fabric1 = simple_model.create_fabric(name="fabric1", material=simple_model.create_material())

--- a/tests/unittests/test_edge_property_list.py
+++ b/tests/unittests/test_edge_property_list.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the EdgePropertyList container."""
+
+import pathlib
+import tempfile
+
+import pytest
+
+from ansys.acp.core import Lamina, SubLaminate
+from ansys.acp.core._typing_helper import PATH
+
+
+@pytest.fixture
+def simple_model(load_model_from_tempfile):
+    with load_model_from_tempfile() as model:
+        yield model
+
+
+@pytest.fixture
+def simple_sublaminate(simple_model, check_simple_sublaminate):
+    """Simple sublaminate whose materials are stored in an edge property list."""
+    sublaminate = simple_model.create_sublaminate(name="simple_sublaminate")
+    sublaminate.add_material(
+        simple_model.create_fabric(name="fabric1", material=simple_model.create_material()),
+        angle=0.0,
+    )
+    sublaminate.add_material(
+        simple_model.create_fabric(name="fabric2", material=simple_model.create_material()),
+        angle=10.0,
+    )
+    check_simple_sublaminate(sublaminate)
+    return sublaminate
+
+
+@pytest.fixture
+def check_simple_sublaminate():
+    """Provides a function to check the simple sublaminate."""
+
+    def check(sublaminate):
+        assert sublaminate.name == "simple_sublaminate"
+        assert len(sublaminate.materials) == 2
+        assert [m.angle for m in sublaminate.materials] == [0.0, 10.0]
+        assert [m.material.name for m in sublaminate.materials] == ["fabric1", "fabric2"]
+
+    return check
+
+
+def test_save_load_with_existing_entries(
+    acp_instance, simple_model, simple_sublaminate, check_simple_sublaminate
+):
+    """Regression test for bug #561.
+
+    Checks that sublaminates are correctly loaded from a saved model.
+    """
+    model = simple_model
+    # GIVEN: a model with a sublaminate which has two materials
+    sublaminate = simple_sublaminate
+
+    # WHEN: the model is saved and loaded
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        if not acp_instance.is_remote:
+            file_path: PATH = pathlib.Path(tmp_dir) / "model.acph5"
+        else:
+            file_path = "model.acph5"
+        model.save(file_path)
+        acp_instance.clear()
+        model = acp_instance.import_model(path=file_path)
+
+    # THEN: the sublaminate is still present and has the same materials
+    sublaminate = model.sublaminates["simple_sublaminate"]
+    check_simple_sublaminate(sublaminate)
+
+
+def test_clone_store(simple_model, simple_sublaminate, check_simple_sublaminate):
+    """Check that the edge property list is preserved when cloning and storing an object."""
+    model = simple_model
+    # GIVEN: a model with a sublaminate which has two materials
+    sublaminate = simple_sublaminate
+
+    # WHEN: cloning the sublaminate, then storing the clone
+    sublaminate_clone = sublaminate.clone()
+    sublaminate_clone.store(parent=model)
+
+    # THEN: the clone is stored and has the same materials
+    check_simple_sublaminate(sublaminate_clone)
+
+
+def test_clone_access_raises(simple_model, simple_sublaminate, check_simple_sublaminate):
+    """Check that the EdgePropertyList cannot be accessed on an unstored object."""
+    model = simple_model
+    # GIVEN: a model with a sublaminate which has two materials
+    sublaminate = simple_sublaminate
+
+    # WHEN: cloning the sublaminate
+    sublaminate_clone = sublaminate.clone()
+
+    # THEN: accessing the materials raises an error
+    with pytest.raises(RuntimeError):
+        sublaminate_clone.materials
+
+
+def test_clone_clear_store(simple_model, simple_sublaminate):
+    """Check that the edge property list can be cleared on a cloned object."""
+    model = simple_model
+    # GIVEN: a model with a sublaminate which has two materials
+    sublaminate = simple_sublaminate
+
+    # WHEN: cloning the sublaminate, removing the materials, then storing the clone
+    sublaminate_clone = sublaminate.clone()
+    sublaminate_clone.materials = []
+    sublaminate_clone.store(parent=model)
+
+    # THEN: the clone is stored and has no materials
+    assert len(sublaminate_clone.materials) == 0
+
+
+def test_store_with_entries(simple_model, check_simple_sublaminate):
+    """Check that a sublaminate can be created with materials, and then stored."""
+    fabric1 = simple_model.create_fabric(name="fabric1", material=simple_model.create_material())
+    fabric2 = simple_model.create_fabric(name="fabric2", material=simple_model.create_material())
+
+    sublaminate = SubLaminate(
+        name="simple_sublaminate",
+        materials=[Lamina(material=fabric1, angle=0.0), Lamina(material=fabric2, angle=10.0)],
+    )
+    sublaminate.store(parent=simple_model)
+    check_simple_sublaminate(sublaminate)
+
+
+def test_wrong_type_raises(simple_model):
+    """Check that assigning a wrong type to the materials raises an error."""
+    sublaminate = simple_model.create_sublaminate(name="simple_sublaminate")
+    with pytest.raises(TypeError):
+        sublaminate.materials = [1]

--- a/tests/unittests/test_edge_property_list.py
+++ b/tests/unittests/test_edge_property_list.py
@@ -27,7 +27,7 @@ import tempfile
 
 import pytest
 
-from ansys.acp.core import Lamina, SubLaminate
+from ansys.acp.core import Fabric, Lamina, SubLaminate
 from ansys.acp.core._typing_helper import PATH
 
 
@@ -153,3 +153,13 @@ def test_wrong_type_raises(simple_model):
     sublaminate = simple_model.create_sublaminate(name="simple_sublaminate")
     with pytest.raises(TypeError):
         sublaminate.materials = [1]
+
+
+def test_incomplete_object_check(simple_model):
+    """Check that unstored objects cannot be added to the edge property list."""
+    sublaminate = simple_model.create_sublaminate(name="simple_sublaminate")
+    with pytest.raises(RuntimeError) as e:
+        sublaminate.materials.append(
+            Lamina(material=Fabric(material=simple_model.create_material()), angle=0.0)
+        )
+    assert "incomplete object" in str(e.value)

--- a/tests/unittests/test_object_permanence.py
+++ b/tests/unittests/test_object_permanence.py
@@ -145,6 +145,9 @@ def test_edge_property_list_parent_deleted(model):
 
 def test_edge_property_list_parent_store(model):
     """Check that the edge property list identity is unique even after its parent is stored."""
+    pytest.xfail(
+        "We no longer allow accessing the edge property list while the parent is unstored."
+    )
     stackup = pyacp.Stackup()
     fabrics = stackup.fabrics
     stackup.store(parent=model)

--- a/tests/unittests/test_sublaminate.py
+++ b/tests/unittests/test_sublaminate.py
@@ -110,7 +110,7 @@ def test_add_lamina(parent_object):
     assert sublaminate.materials[2].angle == -45.0
 
 
-def test_load_with_existing_sublamina(acp_instance, parent_object):
+def test_load_with_existing_sublaminate(acp_instance, parent_object):
     """Regression test for bug #561.
 
     Checks that sublaminates are correctly loaded from a saved model.
@@ -127,6 +127,13 @@ def test_load_with_existing_sublamina(acp_instance, parent_object):
     sublaminate.add_material(fabric1, angle=45.0)
     sublaminate.add_material(stackup, angle=0.0)
     sublaminate.add_material(fabric1, angle=-45.0)
+    assert len(sublaminate.materials) == 3
+    assert sublaminate.materials[0].angle == 45.0
+    assert sublaminate.materials[1].angle == 0.0
+    assert sublaminate.materials[2].angle == -45.0
+    assert isinstance(sublaminate.materials[0].material, Fabric)
+    assert isinstance(sublaminate.materials[1].material, Stackup)
+    assert isinstance(sublaminate.materials[2].material, Fabric)
 
     # WHEN: the model is saved and loaded
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -143,7 +150,7 @@ def test_load_with_existing_sublamina(acp_instance, parent_object):
     assert len(sublaminate.materials) == 3
     assert sublaminate.materials[0].angle == 45.0
     assert sublaminate.materials[1].angle == 0.0
-    assert sublaminate.materials[2].angle == 45.0
+    assert sublaminate.materials[2].angle == -45.0
     assert isinstance(sublaminate.materials[0].material, Fabric)
     assert isinstance(sublaminate.materials[1].material, Stackup)
     assert isinstance(sublaminate.materials[2].material, Fabric)

--- a/tests/unittests/test_sublaminate.py
+++ b/tests/unittests/test_sublaminate.py
@@ -137,7 +137,7 @@ def test_load_with_existing_sublaminate(acp_instance, parent_object):
 
     # WHEN: the model is saved and loaded
     with tempfile.TemporaryDirectory() as tmp_dir:
-        if acp_instance.is_remote:
+        if not acp_instance.is_remote:
             file_path: PATH = pathlib.Path(tmp_dir) / "model.acph5"
         else:
             file_path = "model.acph5"

--- a/tests/unittests/test_sublaminate.py
+++ b/tests/unittests/test_sublaminate.py
@@ -25,7 +25,7 @@ import tempfile
 
 import pytest
 
-from ansys.acp.core import Fabric, FabricWithAngle, Lamina, Stackup, SymmetryType
+from ansys.acp.core import FabricWithAngle, Lamina, SymmetryType
 from ansys.acp.core._typing_helper import PATH
 
 from .common.tree_object_tester import NoLockedMixin, ObjectPropertiesToTest, TreeObjectTester
@@ -110,30 +110,31 @@ def test_add_lamina(parent_object):
     assert sublaminate.materials[2].angle == -45.0
 
 
-def test_load_with_existing_sublaminate(acp_instance, parent_object):
+@pytest.fixture
+def simple_sublaminate(parent_object):
+    sublaminate = parent_object.create_sublaminate(name="simple_sublaminate")
+    sublaminate.add_material(
+        parent_object.create_fabric(name="fabric1", material=parent_object.create_material()),
+        angle=0.0,
+    )
+    sublaminate.add_material(
+        parent_object.create_fabric(name="fabric2", material=parent_object.create_material()),
+        angle=10.0,
+    )
+    return sublaminate
+
+
+def test_load_with_existing_sublaminate(acp_instance, parent_object, simple_sublaminate):
     """Regression test for bug #561.
 
     Checks that sublaminates are correctly loaded from a saved model.
     """
     model = parent_object
-    # GIVEN: a model with a sublaminate which has three materials
-    fabric1 = model.create_fabric()
-    fabric1.material = model.create_material()
-    stackup = model.create_stackup()
-    stackup.add_fabric(fabric1, angle=30.0)
-    stackup.add_fabric(fabric1, angle=-30.0)
-
-    sublaminate = model.create_sublaminate(name="test_sublaminate")
-    sublaminate.add_material(fabric1, angle=45.0)
-    sublaminate.add_material(stackup, angle=0.0)
-    sublaminate.add_material(fabric1, angle=-45.0)
-    assert len(sublaminate.materials) == 3
-    assert sublaminate.materials[0].angle == 45.0
-    assert sublaminate.materials[1].angle == 0.0
-    assert sublaminate.materials[2].angle == -45.0
-    assert isinstance(sublaminate.materials[0].material, Fabric)
-    assert isinstance(sublaminate.materials[1].material, Stackup)
-    assert isinstance(sublaminate.materials[2].material, Fabric)
+    # GIVEN: a model with a sublaminate which has two materials
+    sublaminate = simple_sublaminate
+    assert len(sublaminate.materials) == 2
+    assert [m.angle for m in sublaminate.materials] == [0.0, 10.0]
+    assert [m.material.name for m in sublaminate.materials] == ["fabric1", "fabric2"]
 
     # WHEN: the model is saved and loaded
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -146,11 +147,42 @@ def test_load_with_existing_sublaminate(acp_instance, parent_object):
         model = acp_instance.import_model(path=file_path)
 
     # THEN: the sublaminate is still present and has the same materials
-    sublaminate = model.sublaminates["test_sublaminate"]
-    assert len(sublaminate.materials) == 3
-    assert sublaminate.materials[0].angle == 45.0
-    assert sublaminate.materials[1].angle == 0.0
-    assert sublaminate.materials[2].angle == -45.0
-    assert isinstance(sublaminate.materials[0].material, Fabric)
-    assert isinstance(sublaminate.materials[1].material, Stackup)
-    assert isinstance(sublaminate.materials[2].material, Fabric)
+    sublaminate = model.sublaminates["simple_sublaminate"]
+    assert len(sublaminate.materials) == 2
+    assert [m.angle for m in sublaminate.materials] == [0.0, 10.0]
+    assert [m.material.name for m in sublaminate.materials] == ["fabric1", "fabric2"]
+
+
+def test_clone_edge_property_list(parent_object, simple_sublaminate):
+    model = parent_object
+    # GIVEN: a model with a sublaminate which has two materials
+    sublaminate = simple_sublaminate
+    assert len(sublaminate.materials) == 2
+    assert [m.angle for m in sublaminate.materials] == [0.0, 10.0]
+    assert [m.material.name for m in sublaminate.materials] == ["fabric1", "fabric2"]
+
+    # WHEN: cloning the sublaminate, then storing the clone
+    sublaminate_clone = sublaminate.clone()
+    sublaminate_clone.store(parent=model)
+
+    # THEN: the clone is stored and has the same materials
+    assert len(sublaminate.materials) == 2
+    assert [m.angle for m in sublaminate.materials] == [0.0, 10.0]
+    assert [m.material.name for m in sublaminate.materials] == ["fabric1", "fabric2"]
+
+
+def test_clone_edge_property_list_cleared(parent_object, simple_sublaminate):
+    model = parent_object
+    # GIVEN: a model with a sublaminate which has two materials
+    sublaminate = simple_sublaminate
+    assert len(sublaminate.materials) == 2
+    assert [m.angle for m in sublaminate.materials] == [0.0, 10.0]
+    assert [m.material.name for m in sublaminate.materials] == ["fabric1", "fabric2"]
+
+    # WHEN: cloning the sublaminate, removing the materials, then storing the clone
+    sublaminate_clone = sublaminate.clone()
+    sublaminate_clone.materials = []
+    sublaminate_clone.store(parent=model)
+
+    # THEN: the clone is stored and has no materials
+    assert len(sublaminate_clone.materials) == 0


### PR DESCRIPTION
Fixes #561

The `EdgePropertyList` retains the _same_ list instance during its lifetime 
for containing the edge property wrappers. This is done so that references
user code might hold to its items to correctly update its contents.

In contrast to other types, it means that the state is not re-fetched from
the `_pb_object` if it were to change outside of the `EdgePropertyList`'s
control.
This led to a bug when constructing objects via `_from_object_info`, which
first default-constructs the object (in the process creating the `EdgePropertyList`)
and then modifies the `_pb_object`.

To fix this, the `EdgePropertyList` now stores whether its parent object was
stored when this list was last accessed. If it changes from unstored to stored,
the following logic is applied:
- If the current list is already populated (the "regular" case), only a sanity check
  for matching length is performed
- If the current list is empty, it is re-fetched from the parent object. This is the
  case which occurs during construction with `_from_object_info`

Since the edge property list can be in an inconsistent state (empty when it shouldn't 
be) while the parent is unstored, we disallow accessing it in this state. It is still
allowed however to fully replace the contents.

This PR also fixes a bug in `tree_object_from_resource_path`, where the `channel`
argument was still used instead of `server_wrapper`.