### PR TITLE
Accept empty resource paths in linked objects when storing

### DIFF
--- a/src/ansys/acp/core/_tree_objects/base.py
+++ b/src/ansys/acp/core/_tree_objects/base.py
@@ -306,6 +306,9 @@ class CreatableTreeObject(TreeObject):
         path_values = [collection_path.value] + [
             path.value for _, _, path in linked_path_fields(self._pb_object.properties)
         ]
+        # filter out empty paths
+        path_values = [path for path in path_values if path]
+
         # Since the path starts with 'model/<model_uuid>', the objects belong to
         # the same model iff they share at least the first two parts.
         if len(to_parts(common_path(*path_values))) < 2:


### PR DESCRIPTION
The `.store()` method contains a check that all linked objects are
within the same model. However, this check falsely raised when
given an empty resource path. This is now fixed by filtering out
the empty resource paths in the check.