### PR TITLE
Add step for testing on the released server

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -177,7 +177,7 @@ jobs:
         working-directory: tests/unittests
         run: |
           docker pull $IMAGE_NAME
-          poetry run pytest -v --license-server=1055@$LICENSE_SERVER --no-server-log-files --docker-image=$IMAGE_NAME --cov=ansys.acp.core --cov-report=term --cov-report=xml --cov-report=html
+          poetry run pytest -v --license-server=1055@$LICENSE_SERVER --no-server-log-files --docker-image=$IMAGE_NAME --cov=ansys.acp.core --cov-report=term --cov-report=xml --cov-report=html --cov-append
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
           IMAGE_NAME: "ghcr.io/ansys/acp:2024r2"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -172,6 +172,16 @@ jobs:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
           IMAGE_NAME: "ghcr.io/ansys/acp${{ github.event.inputs.docker_image_suffix || ':latest' }}"
 
+      - name: "Unit testing (2024R2 server)"
+        if: matrix.python-version == ${{ env.MAIN_PYTHON_VERSION }}
+        working-directory: tests/unittests
+        run: |
+          docker pull $IMAGE_NAME
+          poetry run pytest -v --license-server=1055@$LICENSE_SERVER --no-server-log-files --docker-image=$IMAGE_NAME --cov=ansys.acp.core --cov-report=term --cov-report=xml --cov-report=html
+        env:
+          LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
+          IMAGE_NAME: "ghcr.io/ansys/acp:2024r2"
+
       - name: "Upload coverage report (HTML)"
         uses: actions/upload-artifact@v4
         if: matrix.python-version == env.MAIN_PYTHON_VERSION

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -173,7 +173,7 @@ jobs:
           IMAGE_NAME: "ghcr.io/ansys/acp${{ github.event.inputs.docker_image_suffix || ':latest' }}"
 
       - name: "Unit testing (2024R2 server)"
-        if: matrix.python-version == ${{ env.MAIN_PYTHON_VERSION }}
+        if: matrix.python-version == env.MAIN_PYTHON_VERSION
         working-directory: tests/unittests
         run: |
           docker pull $IMAGE_NAME

--- a/src/ansys/acp/core/_tree_objects/base.py
+++ b/src/ansys/acp/core/_tree_objects/base.py
@@ -285,6 +285,9 @@ class CreatableTreeObject(TreeObject):
         new_object_info.properties.CopyFrom(self._pb_object.properties)
         if unlink:
             unlink_objects(new_object_info.properties)
+            # Since there may be links in the unknown fields, we need to
+            # discard them to avoid errors when storing the object.
+            new_object_info.properties.DiscardUnknownFields()  # type: ignore
         new_object_info.info.name = self._pb_object.info.name
         return type(self)._from_object_info(object_info=new_object_info)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,8 +264,8 @@ def load_cad_geometry(model_data_dir, acp_instance):
 
 
 @pytest.fixture
-def xfail_until(acp_instance):
-    """Mark a test as expected to fail until a certain server version."""
+def xfail_before(acp_instance):
+    """Mark a test as expected to fail before a certain server version."""
 
     def inner(version: str):
         if parse_version(acp_instance.server_version) < parse_version(version):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ import tempfile
 
 import docker
 from hypothesis import settings
+from packaging.version import parse as parse_version
 import pytest
 
 from ansys.acp.core import (
@@ -258,5 +259,16 @@ def load_cad_geometry(model_data_dir, acp_instance):
         yield model.create_cad_geometry(
             external_path=cad_file_path,
         )
+
+    return inner
+
+
+@pytest.fixture
+def xfail_until(acp_instance):
+    """Mark a test as expected to fail until a certain server version."""
+
+    def inner(version: str):
+        if parse_version(acp_instance.server_version) < parse_version(version):
+            pytest.xfail(f"Expected to fail until server version {version!r}")
 
     return inner

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -251,11 +251,12 @@ def test_regression_454(minimal_complete_model):
     assert not hasattr(minimal_complete_model, "store")
 
 
-def test_modeling_ply_export(acp_instance, minimal_complete_model):
+def test_modeling_ply_export(acp_instance, minimal_complete_model, xfail_until):
     """
     Test that the 'export_modeling_ply_geometries' method produces a file.
     The contents of the file are not checked.
     """
+    xfail_until("25.1")
     out_filename = "modeling_ply_export.step"
 
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -251,12 +251,12 @@ def test_regression_454(minimal_complete_model):
     assert not hasattr(minimal_complete_model, "store")
 
 
-def test_modeling_ply_export(acp_instance, minimal_complete_model, xfail_until):
+def test_modeling_ply_export(acp_instance, minimal_complete_model, xfail_before):
     """
     Test that the 'export_modeling_ply_geometries' method produces a file.
     The contents of the file are not checked.
     """
-    xfail_until("25.1")
+    xfail_before("25.1")
     out_filename = "modeling_ply_export.step"
 
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Add a step to the tests on Python 3.12 for testing with the 2024R2 server version. [1]

Expected test failures (new features) are marked with the new `xfail_before` fixture. The
only current expected failure is the modeling ply geometry export test (added in 25.1).

Also fixes an issue with the `clone` method when `unlink=True` is specified: Any 
fields unknown to the current client were retained. This caused an error on storing,
since those may be unknown linked objects. In the current case, the newly added 
links to the `Fabric` caused this.
Calling `DiscardUnknownFields()` on the protobuf message fixes this.

[1] Once there are multiple released server versions to test, it probably makes sense to
put these tests into separate jobs.