### PR TITLE
Add regression test for cloning / storing locked element sets

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,3 +276,14 @@ def raises_before_version(acp_instance):
             yield
 
     return inner
+
+
+@pytest.fixture
+def skip_before_version(acp_instance):
+    """Skip a test before a certain server version."""
+
+    def inner(version: str):
+        if parse_version(acp_instance.server_version) < parse_version(version):
+            pytest.skip(f"Test is not supported before version {version}")
+
+    return inner

--- a/tests/unittests/test_element_set.py
+++ b/tests/unittests/test_element_set.py
@@ -66,3 +66,21 @@ class TestElementSet(WithLockedMixin, TreeObjectTester):
 
     CREATE_METHOD_NAME = "create_element_set"
     INITIAL_OBJECT_NAMES = ("All_Elements",)
+
+
+def test_clone_locked(parent_object, skip_before_version):
+    """Test that a locked element set can be correctly cloned.
+
+    Regression test for #565: cloning and storing a locked element
+    set produces an empty element set.
+    The root cause for this issue was that the locked element set
+    did not expose their 'element_labels' in the API.ga
+    """
+    skip_before_version("25.1")
+
+    element_set = parent_object.element_sets["All_Elements"]
+    assert len(element_set.element_labels) > 0
+    cloned_element_set = element_set.clone()
+    cloned_element_set.store(parent=parent_object)
+    assert not cloned_element_set.locked
+    assert len(cloned_element_set.element_labels) > 0


### PR DESCRIPTION
Add a regression test to check that #565 is fixed in the backend.

Closes #565.