### PR TITLE
Fix teardown of direct launcher when start fails

### DIFF
--- a/src/ansys/acp/core/_server/direct.py
+++ b/src/ansys/acp/core/_server/direct.py
@@ -95,7 +95,7 @@ class DirectLauncher(LauncherProtocol[DirectLaunchConfig]):
     def __init__(self, *, config: DirectLaunchConfig):
         self._config = config
         self._url: str
-        self._process: subprocess.Popen[str]
+        self._process: subprocess.Popen[str] | None = None
         self._stdout: TextIO
         self._stderr: TextIO
 
@@ -123,6 +123,9 @@ class DirectLauncher(LauncherProtocol[DirectLaunchConfig]):
         )
 
     def stop(self, *, timeout: float | None = None) -> None:
+        if self._process is None:
+            # The process has not been started, and therefore doesn't need to be stopped
+            return
         self._process.terminate()
         try:
             self._process.wait(timeout=timeout)

--- a/tests/unittests/test_direct_launcher.py
+++ b/tests/unittests/test_direct_launcher.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2022 - 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+import ansys.acp.core as pyacp
+from ansys.acp.core._server.direct import DirectLauncher
+
+
+def test_inexistent_binary_error():
+    """Check that the right error is raised when the binary does not exist."""
+    with pytest.raises(FileNotFoundError) as exc:
+        pyacp.launch_acp(
+            launch_mode=pyacp.LaunchMode.DIRECT,
+            config=pyacp.DirectLaunchConfig(binary_path="inexistent_path"),
+        )
+    assert "Binary not found" in str(exc.value)
+
+
+def test_stop_after_failed_start():
+    """Check that the .stop() method works after a failed start.
+
+    This test is necessary because the '.stop()' method is called on teardown
+    even if the '.start()' method fails.
+    In the 'test_inexistent_binary_error' test, errors in '.stop()' are not
+    captured because they happen after the test ends.
+    """
+    launcher = DirectLauncher(config=pyacp.DirectLaunchConfig(binary_path="inexistent_path"))
+    with pytest.raises(FileNotFoundError):
+        launcher.start()
+    launcher.stop()


### PR DESCRIPTION
The direct launcher `.stop()` errored when `.start()` had failed, since the `_process` attribute was not yet defined. This caused the error message to be misleading, as it was pointing to the error in `.stop()` first, instead of the actual error in `.start()`.

This is fixed by explicitly setting `_process` to None in the constructor of the DirectLauncher class, and checking if it is not None before trying to stop it.

See backend issue 1161518.