### PR TITLE
Allow loading materials from MatML XML

### DIFF
--- a/src/ansys/acp/core/_tree_objects/model.py
+++ b/src/ansys/acp/core/_tree_objects/model.py
@@ -450,10 +450,11 @@ class Model(TreeObject):
         Import materials from a MatML file.
 
         Import materials from a ``MatML.xml`` (Engineering Data) file.
-        
+
         Optionally, a material APDL file can be defined. This is a pre-generated
         solver snippet, needed in case of variable materials or non-standard
-        material models.
+        material models. The snippet is used when exporting solid models or
+        surface section cuts in the CDB format.
 
         Parameters
         ----------

--- a/src/ansys/acp/core/_tree_objects/model.py
+++ b/src/ansys/acp/core/_tree_objects/model.py
@@ -449,8 +449,11 @@ class Model(TreeObject):
         """
         Import materials from a MatML file.
 
-        Import materials from a ``MatML.xml`` file, and optionally from an associated
-        material APDL file.
+        Import materials from a ``MatML.xml`` (Engineering Data) file.
+        
+        Optionally, a material APDL file can be defined. This is a pre-generated
+        solver snippet, needed in case of variable materials or non-standard
+        material models.
 
         Parameters
         ----------

--- a/src/ansys/acp/core/_tree_objects/model.py
+++ b/src/ansys/acp/core/_tree_objects/model.py
@@ -439,6 +439,43 @@ class Model(TreeObject):
                 )
             )
 
+    @supported_since("25.1")
+    def import_materials(
+        self,
+        matml_path: _PATH,
+        *,
+        material_apdl_path: _PATH | None = None,
+    ) -> None:
+        """
+        Import materials from a MatML file.
+
+        Import materials from a ``MatML.xml`` file, and optionally from an associated
+        material APDL file.
+
+        Parameters
+        ----------
+        matml_path:
+            File path to the MatML file.
+        material_apdl_path:
+            File path to the material APDL file.
+        """
+        material_stub = material_pb2_grpc.ObjectServiceStub(self._channel)
+        collection_path = CollectionPath(
+            value=rp_join(self._resource_path.value, Material._COLLECTION_LABEL)
+        )
+        with wrap_grpc_errors():
+            material_stub.ImportMaterialFiles(
+                material_pb2.ImportMaterialFilesRequest(
+                    collection_path=collection_path,
+                    matml_path=path_to_str_checked(matml_path),
+                    material_apdl_path=(
+                        path_to_str_checked(material_apdl_path)
+                        if material_apdl_path is not None
+                        else ""
+                    ),
+                )
+            )
+
     def export_materials(self, path: _PATH) -> None:
         """
         Write materials to a XML (MatML) file.

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -330,7 +330,7 @@ def test_material_export(acp_instance, minimal_complete_model, tempdir_if_local_
             assert os.stat(local_file_path).st_size > 0
 
 
-def test_material_import(acp_instance, minimal_complete_model, tempdir_if_local_acp):
+def test_material_import(minimal_complete_model, tempdir_if_local_acp, raises_before_version):
     # GIVEN: a model, and a material XML file containing a material which is
     # not present in the model
 
@@ -344,8 +344,9 @@ def test_material_import(acp_instance, minimal_complete_model, tempdir_if_local_
         del minimal_complete_model.materials[new_mat_id]
         assert new_mat_id not in minimal_complete_model.materials
 
-        # WHEN: the materials are imported
-        minimal_complete_model.import_materials(export_file_path)
+        with raises_before_version("25.1"):
+            # WHEN: the materials are imported
+            minimal_complete_model.import_materials(export_file_path)
 
-        # THEN: the new material should be present in the model
-        assert new_mat_id in minimal_complete_model.materials
+            # THEN: the new material should be present in the model
+            assert new_mat_id in minimal_complete_model.materials

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -314,3 +314,38 @@ def test_change_unit_system(minimal_complete_model, unit_system, raises_before_v
                 minimal_complete_model.minimum_analysis_ply_thickness,
                 initial_minimum_analysis_ply_thickness * conversion_factor_by_us[unit_system.value],
             )
+
+
+def test_material_export(acp_instance, minimal_complete_model, tempdir_if_local_acp):
+    """Check that the 'export_materials' method produces a file."""
+    with tempdir_if_local_acp() as export_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            export_file_path = pathlib.Path(export_dir) / "material_exported.xml"
+            local_file_path = pathlib.Path(tmp_dir) / "material_exported.xml"
+
+            minimal_complete_model.export_materials(export_file_path)
+            acp_instance.download_file(export_file_path, local_file_path)
+
+            assert local_file_path.exists()
+            assert os.stat(local_file_path).st_size > 0
+
+
+def test_material_import(acp_instance, minimal_complete_model, tempdir_if_local_acp):
+    # GIVEN: a model, and a material XML file containing a material which is
+    # not present in the model
+
+    with tempdir_if_local_acp() as export_dir:
+        new_mat_id = "New Material"
+        export_file_path = pathlib.Path(export_dir) / "material_exported.xml"
+        mat = minimal_complete_model.materials["Structural Steel"].clone()
+        mat.name = new_mat_id
+        mat.store(parent=minimal_complete_model)
+        minimal_complete_model.export_materials(export_file_path)
+        del minimal_complete_model.materials[new_mat_id]
+        assert new_mat_id not in minimal_complete_model.materials
+
+        # WHEN: the materials are imported
+        minimal_complete_model.import_materials(export_file_path)
+
+        # THEN: the new material should be present in the model
+        assert new_mat_id in minimal_complete_model.materials


### PR DESCRIPTION
Add exposure of the `ImportMaterialFiles` API method.

Adds basic tests for both material export and import.

Closes #477 
