### PR TITLE
Add vulnerability check CI job

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -106,6 +106,17 @@ jobs:
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
 
+  check-vulnerabilities:
+    name: "Check library vulnerabilities"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ansys/actions/check-vulnerabilities@v8.1
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          python-package-name: 'ansys-acp-core'
+          dev-mode: ${{ github.ref != 'refs/heads/main' }}
+
   testing:
     name: Testing
     runs-on: ubuntu-latest
@@ -418,7 +429,7 @@ jobs:
   build:
     name: Build library
     runs-on: ubuntu-latest
-    needs: [code-style, testing, doc-style, docs, build-wheelhouse, doctest]
+    needs: [code-style, testing, doc-style, docs, build-wheelhouse, doctest, check-vulnerabilities]
     timeout-minutes: 30
     steps:
       - name: Build library source and wheel artifacts

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -429,7 +429,7 @@ jobs:
   build:
     name: Build library
     runs-on: ubuntu-latest
-    needs: [code-style, testing, doc-style, docs, build-wheelhouse, doctest, check-vulnerabilities]
+    needs: [code-style, testing, doc-style, docs, build-wheelhouse, doctest] # TODO: add check-vulnerabilities once we know it works on main
     timeout-minutes: 30
     steps:
       - name: Build library source and wheel artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ examples/pymechanical/output/*
 
 /examples/workbench_project/
 
+# Vulnerability scanning
+info_bandit.json
+info_safety.json

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -11,3 +11,4 @@ section provides in-depth explanations.
 
     howto/index
     concepts/index
+    security_considerations

--- a/doc/source/user_guide/security_considerations.rst
+++ b/doc/source/user_guide/security_considerations.rst
@@ -6,10 +6,12 @@ of PyACP. It is important to understand the capabilities which PyACP
 provides, especially when using it to build apps or scripts that accept
 untrusted input.
 
+.. _security_launch_acp:
+
 Launching ACP
 -------------
 
-The :py:func:`launch_acp` function has different security implications depending
+The :py:func:`.launch_acp` function has different security implications depending
 on the launch mode used:
 
 Direct launch
@@ -52,6 +54,8 @@ Connect launch
 The ``"connect"`` launch mode connects to an existing ACP server. This mode does
 not pose any particular security risks, besides allowing access to a port on the
 system.
+
+.. _security_file_upload_download:
 
 File up- and downloads
 ----------------------

--- a/doc/source/user_guide/security_considerations.rst
+++ b/doc/source/user_guide/security_considerations.rst
@@ -1,0 +1,63 @@
+Security considerations
+=======================
+
+This section provides information on security considerations for the use
+of PyACP. It is important to understand the capabilities which PyACP
+provides, especially when using it to build apps or scripts that accept
+untrusted input.
+
+Launching ACP
+-------------
+
+The :py:func:`launch_acp` function has different security implications depending
+on the launch mode used:
+
+Direct launch
+^^^^^^^^^^^^^
+
+When using the ``"direct"`` launch mode:
+
+- The executable which is launched is configurable either in the function
+  parameters, or in the ``ansys-tools-local-product-launcher`` configuration
+  file. This may allow an attacker to launch arbitrary executables on the system.
+- The standard output and standard error file paths are configurable. This may
+  be used to overwrite arbitrary files on the system.
+
+When exposing the ``"direct"`` launch mode to untrusted users, it is important
+to validate that the executable path and file paths are safe, or hard-code
+them in the app.
+
+Docker compose launch
+^^^^^^^^^^^^^^^^^^^^^
+
+The ``"docker_compose"`` launch mode executes the ``docker`` or ``docker-compose``
+commands on the system.
+
+This may pose the following risks:
+
+- If the user can override which container is launched, they may be able to
+  launch arbitrary containers on the system. This is especially problematic
+  if ``docker`` is configured to run with elevated privileges.
+- If the user can override the ``docker`` or ``docker-compose`` executable
+  in the environment, they may be able to execute arbitrary commands on the
+  system.
+
+When exposing the ``"docker_compose"`` launch mode to untrusted users, it is important
+to validate that the container being launched, and control the environment the
+command is executed in.
+
+Connect launch
+^^^^^^^^^^^^^^
+
+The ``"connect"`` launch mode connects to an existing ACP server. This mode does
+not pose any particular security risks, besides allowing access to a port on the
+system.
+
+File up- and downloads
+----------------------
+
+The :py:meth:`.ACP.upload_file` and :py:meth:`.ACP.download_file` methods create files
+on the local or remote machine, without any validation of the file content or path.
+
+When exposing these methods to untrusted users, it is important to validate that
+only files that are safe to be uploaded or downloaded are processed.

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -8,3 +8,4 @@ GUI
 Mechanical
 APDL
 API
+untrusted

--- a/src/.bandit
+++ b/src/.bandit
@@ -1,0 +1,8 @@
+# TODO: move this configuration into the main 'pyproject.toml' file
+# once this is supported by the check-vulnerabilities action.
+
+# Skipping B101:assert_used. Assert statements should not be used to
+# check for 'regular' error conditions, but rather for detecting internal
+# errors that should never occur.
+[bandit]
+skips = B101

--- a/src/ansys/acp/core/_server/acp_instance.py
+++ b/src/ansys/acp/core/_server/acp_instance.py
@@ -227,6 +227,12 @@ class ACP(Generic[ServerT]):
     def upload_file(self, local_path: _PATH) -> pathlib.PurePath:
         """Upload a file to the server.
 
+        .. warning::
+
+            Do not execute this function with untrusted input parameters.
+            See the :ref:`security guide<security_file_upload_download>`
+            for details.
+
         Parameters
         ----------
         local_path :
@@ -241,6 +247,12 @@ class ACP(Generic[ServerT]):
 
     def download_file(self, remote_filename: _PATH, local_path: _PATH) -> None:
         """Download a file from the server.
+
+        .. warning::
+
+            Do not execute this function with untrusted input parameters.
+            See the :ref:`security guide<security_file_upload_download>`
+            for details.
 
         Parameters
         ----------

--- a/src/ansys/acp/core/_server/direct.py
+++ b/src/ansys/acp/core/_server/direct.py
@@ -23,7 +23,7 @@
 import dataclasses
 import os
 import pathlib
-import subprocess
+import subprocess  # nosec B404
 from typing import TextIO
 
 import grpc
@@ -112,7 +112,7 @@ class DirectLauncher(LauncherProtocol[DirectLaunchConfig]):
         self._url = f"localhost:{port}"
         self._stdout = open(stdout_file, mode="w", encoding="utf-8")
         self._stderr = open(stderr_file, mode="w", encoding="utf-8")
-        self._process = subprocess.Popen(
+        self._process = subprocess.Popen(  # nosec B603: documented in 'security_considerations.rst'
             [
                 self._config.binary_path,
                 f"--server-address=0.0.0.0:{port}",

--- a/src/ansys/acp/core/_server/docker_compose.py
+++ b/src/ansys/acp/core/_server/docker_compose.py
@@ -29,7 +29,7 @@ import importlib.resources
 import math
 import os
 import pathlib
-import subprocess
+import subprocess  # nosec B404
 import uuid
 
 import grpc
@@ -139,17 +139,21 @@ class DockerComposeLauncher(LauncherProtocol[DockerComposeLaunchConfig]):
 
         try:
             self._compose_version = parse_version(
-                subprocess.check_output(
+                subprocess.check_output(  # nosec B603, B607: documented in 'security_considerations.rst'
                     ["docker", "compose", "version", "--short"], text=True
-                ).replace("-", "+")
+                ).replace(
+                    "-", "+"
+                )
             )
             self._compose_cmds = ["docker", "compose"]
         except subprocess.CalledProcessError:
             # If 'docker compose does not work, try 'docker-compose' instead.
             self._compose_version = parse_version(
-                subprocess.check_output(
+                subprocess.check_output(  # nosec B603, B607: documented in 'security_considerations.rst'
                     ["docker-compose", "version", "--short"], text=True
-                ).replace("-", "+")
+                ).replace(
+                    "-", "+"
+                )
             )
             self._compose_cmds = ["docker-compose"]
 
@@ -188,7 +192,7 @@ class DockerComposeLauncher(LauncherProtocol[DockerComposeLaunchConfig]):
                 # The '--wait' flag is only available from version >= 2.1.1 of docker compose:
                 # https://github.com/docker/compose/commit/72e4519cbfb6cdfc600e6ebfa377ce4b8e162c78
                 cmd.append("--wait")
-            subprocess.check_call(
+            subprocess.check_call(  # nosec B603: documented in 'security_considerations.rst'
                 cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
 
@@ -208,7 +212,11 @@ class DockerComposeLauncher(LauncherProtocol[DockerComposeLaunchConfig]):
                 cmd.extend(["--timeout", str(math.ceil(timeout))])
             if not self._keep_volume:
                 cmd.append("--volumes")
-            subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.check_call(  # nosec B603: documented in 'security_considerations.rst'
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
 
     def check(self, timeout: float | None = None) -> bool:
         for url in self.urls.values():

--- a/src/ansys/acp/core/_server/launch.py
+++ b/src/ansys/acp/core/_server/launch.py
@@ -51,6 +51,11 @@ def launch_acp(
     Launch the ACP gRPC server with the given configuration. If no
     configuration is provided, the configured default is used.
 
+    .. warning::
+
+        Do not execute this function with untrusted input parameters.
+        See the :ref:`security guide<security_launch_acp>` for details.
+
     Parameters
     ----------
     config :

--- a/src/ansys/acp/core/example_helpers.py
+++ b/src/ansys/acp/core/example_helpers.py
@@ -113,7 +113,8 @@ def _get_file_url(example_location: _ExampleLocation) -> str:
 
 def _download_file(example_location: _ExampleLocation, local_path: pathlib.Path) -> None:
     file_url = _get_file_url(example_location)
-    urllib.request.urlretrieve(file_url, local_path)
+    # The URL is hard-coded to start with the example repository URL, so it is safe to use
+    urllib.request.urlretrieve(file_url, local_path)  # nosec: B310
 
 
 def _run_analysis(workflow: "ACPWorkflow") -> None:


### PR DESCRIPTION
Add usage of the `check-vulnerabilities` action, to check for code vulnerabilities.

Checks for the use of `assert` are globally disabled. The reason for this check is that
`assert` can be misused to check for invalid input, but we use it to validate programmer
assumptions (i.e., they should never raise unless there is a bug).

For the identified issues which were ignored (related to launching the ACP gRPC
server executable), a "security considerations" page is added to the documentation.

Since we are not certain if the `check-vulnerabilities` action works on `main` with
current permissions, CI is configured to continue when it fails.