### PR TITLE
Add 2025R2 to the list of tested server versions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -130,6 +130,8 @@ jobs:
             server-version: "2024R2"
           - python-version: "3.12"
             server-version: "2025R1"
+          - python-version: "3.12"
+            server-version: "2025R2"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Add an explicit task for running test with the 2025R2 (current dev) server version.