### PR TITLE
Benchmark: fix and re-enable 100ms delay case

### DIFF
--- a/src/ansys/acp/core/_server/acp_instance.py
+++ b/src/ansys/acp/core/_server/acp_instance.py
@@ -198,10 +198,10 @@ class ACP(Generic[ServerT]):
         saving them to a file.
         """
         model_stub = model_pb2_grpc.ObjectServiceStub(self._channel)
-        for model in model_stub.List(
-            ListRequest(collection_path=CollectionPath(value=Model._COLLECTION_LABEL))
-        ).objects:
-            with wrap_grpc_errors():
+        with wrap_grpc_errors():
+            for model in model_stub.List(
+                ListRequest(collection_path=CollectionPath(value=Model._COLLECTION_LABEL))
+            ).objects:
                 model_stub.Delete(
                     DeleteRequest(
                         resource_path=model.info.resource_path, version=model.info.version

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -111,10 +111,7 @@ NETWORK_OPTIONS = [
     ServerNetworkOptions(delay_ms=0, rate_kbit=1e6),
     ServerNetworkOptions(delay_ms=1, rate_kbit=1e6),
     ServerNetworkOptions(delay_ms=10, rate_kbit=1e6),
-    # Currently disabled since the server fails to start correctly.
-    # See https://github.com/ansys/pyacp/issues/634
-    #
-    # ServerNetworkOptions(delay_ms=100, rate_kbit=1e6),
+    ServerNetworkOptions(delay_ms=100, rate_kbit=1e6),
     ServerNetworkOptions(delay_ms=0, rate_kbit=1e4),
     ServerNetworkOptions(delay_ms=0, rate_kbit=1e3),
     ServerNetworkOptions(delay_ms=0, rate_kbit=1e2),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,8 @@ NO_SERVER_LOGS_OPTION_KEY = "--no-server-log-files"
 BUILD_BENCHMARK_IMAGE_OPTION_KEY = "--build-benchmark-image"
 VALIDATE_BENCHMARKS_ONLY_OPTION_KEY = "--validate-benchmarks-only"
 SERVER_STARTUP_TIMEOUT = 30.0
-SERVER_STOP_TIMEOUT = 1.0
+SERVER_STOP_TIMEOUT = 2.0
+SERVER_CHECK_TIMEOUT = 2.0
 
 pytest.register_assert_rewrite("common")
 
@@ -219,7 +220,7 @@ def check_grpc_server_before_run(
 ) -> Generator[None, None, None]:
     """Check if the server still responds before running each test, otherwise restart it."""
     try:
-        acp_instance.wait(timeout=1.0)
+        acp_instance.wait(timeout=SERVER_CHECK_TIMEOUT)
     except RuntimeError:
         acp_instance.restart(stop_timeout=SERVER_STOP_TIMEOUT)
         acp_instance.wait(timeout=SERVER_STARTUP_TIMEOUT)


### PR DESCRIPTION
Fix the 100ms delay benchmark case, by increasing the timeout
when checking whether the server is still running from 1 to 2
seconds.

Closes #634.