### PR TITLE
Document how to plot data on parts of the mesh

### DIFF
--- a/doc/source/user_guide/howto/visualize_model.rst
+++ b/doc/source/user_guide/howto/visualize_model.rst
@@ -21,7 +21,7 @@ Visualize model
         ...     ExampleKeys.RACE_CAR_NOSE_ACPH5, pathlib.Path(tempdir.name)
         ... )
         >>> path = acp.upload_file(input_file)
-        >>> model = acp.import_model(path=path)
+        >>> model = acp.import_model(path)
 
         >>> input_file_geometry = get_example_file(
         ...     ExampleKeys.RACE_CAR_NOSE_STEP, pathlib.Path(tempdir.name)
@@ -41,6 +41,14 @@ Visualize model
 
         >>> model.mesh.to_pyvista().plot()
 
+    You can also access and plot the mesh data for specific tree objects. For example, the following code plots the mesh for a modeling ply.
+
+    .. pyvista-plot::
+        :context:
+
+        >>> modeling_ply = model.modeling_groups['nose'].modeling_plies['mp.nose.4']
+        >>> modeling_ply.mesh.to_pyvista().plot()
+
 
     .. _directions_plotter:
 
@@ -54,7 +62,6 @@ Visualize model
     .. pyvista-plot::
         :context:
 
-        >>> modeling_ply = model.modeling_groups['nose'].modeling_plies['mp.nose.4']
         >>> elemental_data = modeling_ply.elemental_data
         >>> directions_plotter = pyacp.get_directions_plotter(
         ...     model=model,
@@ -68,6 +75,23 @@ Visualize model
         >>> directions_plotter.show()
 
     The color scheme used in this plot for the various components matches the ACP GUI.
+
+    The directions plot can be scoped to a specific region of the model by using the ``mesh`` parameter. For example, the following code only plots the part covered by the modeling ply.
+
+    .. pyvista-plot::
+        :context:
+
+        >>> directions_plotter = pyacp.get_directions_plotter(
+        ...     model=model,
+        ...     mesh=modeling_ply.mesh,
+        ...     components=[
+        ...         elemental_data.orientation,
+        ...         elemental_data.fiber_direction
+        ...     ],
+        ...     length_factor=10.,
+        ...     culling_factor=10,
+        ... )
+        >>> directions_plotter.show()
 
     Showing the mesh data
     ~~~~~~~~~~~~~~~~~~~~~
@@ -87,6 +111,14 @@ Visualize model
 
         >>> thickness_data = model.elemental_data.thickness
         >>> pyvista_mesh = thickness_data.get_pyvista_mesh(mesh=model.mesh)
+        >>> pyvista_mesh.plot()
+
+    Again, the ``mesh`` parameter can be used to limit the scope of the plot.
+
+    .. pyvista-plot::
+        :context:
+
+        >>> pyvista_mesh = thickness_data.get_pyvista_mesh(mesh=model.element_sets["els_wing_assembly"].mesh)
         >>> pyvista_mesh.plot()
 
     Vector data

--- a/src/ansys/acp/core/_plotter.py
+++ b/src/ansys/acp/core/_plotter.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import pyvista
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ansys.acp.core import Model
     from ansys.acp.core import MeshData
     from ansys.acp.core import VectorData

--- a/src/ansys/acp/core/_plotter.py
+++ b/src/ansys/acp/core/_plotter.py
@@ -27,6 +27,7 @@ import pyvista
 
 if TYPE_CHECKING:
     from ansys.acp.core import Model
+    from ansys.acp.core import MeshData
     from ansys.acp.core import VectorData
 
 from ansys.acp.core._utils.visualization import _replace_underscores_and_capitalize
@@ -48,6 +49,7 @@ _acp_direction_colors = {
 def get_directions_plotter(
     *,
     model: "Model",
+    mesh: "MeshData | None" = None,
     components: Sequence[Optional["VectorData"]],
     culling_factor: int = 1,
     length_factor: float = 1.0,
@@ -57,8 +59,13 @@ def get_directions_plotter(
 
     Parameters
     ----------
-    model:
-        ACP Model.
+    model :
+        ACP model. Determines the average element size used for scaling the
+        arrows. Unless explicitly specified, the model also determines the
+        mesh to plot.
+    mesh :
+        Mesh defining the scope of the plot. If not provided, the full mesh
+        of the model is used.
     components:
         List of components to plot.
     culling_factor :
@@ -70,9 +77,11 @@ def get_directions_plotter(
     kwargs :
         Keyword arguments passed to the PyVista object constructor.
     """
+    if mesh is None:
+        mesh = model.mesh
 
     plotter = pyvista.Plotter()
-    plotter.add_mesh(model.mesh.to_pyvista(), color="white", show_edges=True)
+    plotter.add_mesh(mesh.to_pyvista(), color="white", show_edges=True)
 
     for vector_data in components:
         if vector_data is None:
@@ -80,7 +89,7 @@ def get_directions_plotter(
         color = _acp_direction_colors.get(vector_data.component_name, "black")
         plotter.add_mesh(
             vector_data.get_pyvista_glyphs(
-                mesh=model.mesh,
+                mesh=mesh,
                 factor=model.average_element_size * length_factor,
                 culling_factor=culling_factor,
                 **kwargs,

--- a/src/ansys/acp/core/_typing_helper.py
+++ b/src/ansys/acp/core/_typing_helper.py
@@ -36,7 +36,7 @@ PATH = Union[str, os.PathLike[str]]
 # the enum member.
 # When type checking, always use the Python 3.10 workaround, otherwise
 # the StrEnum resolves as 'Any'.
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
 
     class StrEnum(str, enum.Enum):
         """String enum."""

--- a/src/ansys/acp/core/extras/example_helpers.py
+++ b/src/ansys/acp/core/extras/example_helpers.py
@@ -35,7 +35,7 @@ __all__ = ["ExampleKeys", "get_example_file"]
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ansys.acp.core import ACPWorkflow
 
 _EXAMPLE_REPO = "https://github.com/ansys/example-data/raw/master/pyacp/"

--- a/tests/unittests/common/linked_object_list_tester.py
+++ b/tests/unittests/common/linked_object_list_tester.py
@@ -26,7 +26,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from mypy_extensions import DefaultNamedArg, KwArg
 
 import pytest

--- a/tests/unittests/test_plot_utils.py
+++ b/tests/unittests/test_plot_utils.py
@@ -20,11 +20,37 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import pytest
+from pytest_cases import parametrize_with_cases
+
 from ansys.acp.core._plotter import get_directions_plotter
 from ansys.acp.core._utils.visualization import _replace_underscores_and_capitalize
 
 
-def test_direction_plotter(acp_instance, load_model_from_tempfile):
+@pytest.fixture
+def model(load_model_from_tempfile):
+    with load_model_from_tempfile() as model:
+        yield model
+
+
+def case_mesh_none_valid():
+    return None
+
+
+def case_model_mesh_valid(model):
+    return model.mesh
+
+
+def case_other_mesh_valid(model):
+    return model.element_sets["All_Elements"].mesh
+
+
+def case_empty_mesh_invalid(model):
+    return model.create_element_set().mesh
+
+
+@parametrize_with_cases("mesh", cases=".", glob="*_valid")
+def test_direction_plotter_valid_cases(model, mesh, load_model_from_tempfile):
     with load_model_from_tempfile() as model:
         modeling_ply = model.modeling_groups["ModelingGroup.1"].modeling_plies["ModelingPly.1"]
         analysis_ply = modeling_ply.production_plies["ProductionPly"].analysis_plies[
@@ -42,10 +68,36 @@ def test_direction_plotter(acp_instance, load_model_from_tempfile):
         ]
         plotter = get_directions_plotter(
             model=model,
+            mesh=mesh,
             components=components,
         )
 
         for idx, data in enumerate(components):
             assert plotter.legend.GetEntryString(idx) == _replace_underscores_and_capitalize(
                 data.component_name
+            )
+
+
+@parametrize_with_cases("mesh", cases=".", glob="*_invalid")
+def test_direction_plotter_invalid_cases(model, mesh, load_model_from_tempfile):
+    with load_model_from_tempfile() as model:
+        modeling_ply = model.modeling_groups["ModelingGroup.1"].modeling_plies["ModelingPly.1"]
+        analysis_ply = modeling_ply.production_plies["ProductionPly"].analysis_plies[
+            "P1L1__ModelingPly.1"
+        ]
+        components = [
+            analysis_ply.elemental_data.orientation,
+            analysis_ply.elemental_data.normal,
+            analysis_ply.elemental_data.reference_direction,
+            analysis_ply.elemental_data.fiber_direction,
+            analysis_ply.elemental_data.transverse_direction,
+            analysis_ply.elemental_data.draped_fiber_direction,
+            analysis_ply.elemental_data.draped_transverse_direction,
+            analysis_ply.elemental_data.material_1_direction,
+        ]
+        with pytest.raises(KeyError):
+            get_directions_plotter(
+                model=model,
+                mesh=mesh,
+                components=components,
             )

--- a/tests/unittests/test_plot_utils.py
+++ b/tests/unittests/test_plot_utils.py
@@ -41,11 +41,13 @@ def case_model_mesh_valid(model):
     return model.mesh
 
 
-def case_other_mesh_valid(model):
+def case_other_mesh_valid(model, skip_before_version):
+    skip_before_version("25.1")
     return model.element_sets["All_Elements"].mesh
 
 
-def case_empty_mesh_invalid(model):
+def case_empty_mesh_invalid(model, skip_before_version):
+    skip_before_version("25.1")
     return model.create_element_set().mesh
 
 


### PR DESCRIPTION
Document that the 'mesh' parameter can be used when generating the PyVista objects to limit the scope of the created object.