### PR TITLE
Fix links at the end of the getting started page

### DIFF
--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -3,24 +3,30 @@
 API reference
 =============
 
-This section describes the API of the public PyACP classes, functions,
-and attributes.
+.. jinja:: conditional_skip
 
-.. currentmodule:: ansys.acp.core
+    {$ if not skip_api $}
+    This section describes the API of the public PyACP classes, functions,
+    and attributes.
 
-.. toctree::
-    :maxdepth: 2
+    .. currentmodule:: ansys.acp.core
 
-    server
-    tree_objects
-    mesh_data
-    linked_object_definitions
-    material_property_sets
-    enum_types
-    other_types
-    plot_utils
-    other_utils
-    workflow
-    example_helpers
-    mechanical_integration_helpers
-    internal
+    .. toctree::
+        :maxdepth: 2
+
+        server
+        tree_objects
+        mesh_data
+        linked_object_definitions
+        material_property_sets
+        enum_types
+        other_types
+        plot_utils
+        other_utils
+        workflow
+        example_helpers
+        mechanical_integration_helpers
+        internal
+    {% else %}
+    The API reference is not available in this documentation build.
+    {% endif %}

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -5,7 +5,7 @@ API reference
 
 .. jinja:: conditional_skip
 
-    {$ if not skip_api $}
+    {% if not skip_api %}
     This section describes the API of the public PyACP classes, functions,
     and attributes.
 

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -1,3 +1,5 @@
+.. _api_reference:
+
 API reference
 =============
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -110,10 +110,14 @@ from ansys.acp.core import __version__
 SKIP_GALLERY = os.environ.get("PYACP_DOC_SKIP_GALLERY", "0").lower() in ("1", "true")
 SKIP_API = os.environ.get("PYACP_DOC_SKIP_API", "0").lower() in ("1", "true")
 
-exclude_patterns = []
+# nested example index files are directly included in the parent index file
+exclude_patterns = ["examples/*/index.rst"]
 if SKIP_API:
     # Exclude all API documentation except the index
-    exclude_patterns.append("api/[!index]*.rst")
+    # The 'api/!(index).rst' syntax does not appear to be supported by Sphinx
+    for file_path in pathlib.Path("api").glob("**/*.rst"):
+        if str(file_path) != "api/index.rst":
+            exclude_patterns.append(str(file_path))
 
 
 jinja_contexts = {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -112,7 +112,8 @@ SKIP_API = os.environ.get("PYACP_DOC_SKIP_API", "0").lower() in ("1", "true")
 
 exclude_patterns = []
 if SKIP_API:
-    exclude_patterns.append("api/*")
+    # Exclude all API documentation except the index
+    exclude_patterns.append("api/[!index]*.rst")
 
 
 jinja_contexts = {

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -1,3 +1,5 @@
+.. _contributing:
+
 Contribute
 ==========
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,16 +1,14 @@
-.. jinja:: conditional_skip
 
-    .. toctree::
-        :hidden:
-        :maxdepth: 3
 
-        intro
-        user_guide/index
-        examples/index
-        {% if not skip_api %}
-        api/index
-        {% endif %}
-        contributing
+.. toctree::
+    :hidden:
+    :maxdepth: 3
+
+    intro
+    user_guide/index
+    examples/index
+    api/index
+    contributing
 
 
 PyACP

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,6 +4,7 @@
     :hidden:
     :maxdepth: 3
 
+    PyACP home<self>
     intro
     user_guide/index
     examples/index
@@ -33,40 +34,39 @@ optimization of composite structures.
         :gutter: 2
 
         .. grid-item-card:: :octicon:`rocket` Getting started
-            :link: intro
-            :link-type: doc
+            :link: getting_started
+            :link-type: ref
 
             Contains installation instructions and a simple example to get you
             started with PyACP.
 
         .. grid-item-card:: :octicon:`tools` How-to guides
-            :link: user_guide/howto/index
-            :link-type: doc
+            :link: howto
+            :link-type: ref
 
             Guides on how to achieve specific tasks with PyACP.
 
         .. grid-item-card:: :octicon:`light-bulb` Concepts
-            :link: user_guide/concepts/index
-            :link-type: doc
+            :link: concepts
+            :link-type: ref
 
             Explains the concepts and terminology used in PyACP.
 
         .. grid-item-card:: :octicon:`play` Examples
-            :link: examples/index
-            :link-type: doc
+            :link: ref_examples
+            :link-type: ref
 
             A collection of examples demonstrating the capabilities of PyACP.
 
         .. grid-item-card:: :octicon:`file-code` API reference
-            {% if not skip_api %}:link: api/index
-            :link-type: doc
-            {% endif %}
+            :link: api_reference
+            :link-type: ref
 
             Describes the public Python classes, methods, and functions.
 
         .. grid-item-card:: :octicon:`code` Contributing
             :link: contributing
-            :link-type: doc
+            :link-type: ref
 
             Information on how to contribute to PyACP.
 

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -1,3 +1,5 @@
+.. _getting_started:
+
 Getting started
 ---------------
 

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -153,9 +153,9 @@ Continue exploring
 
 This is just a brief introduction to PyACP. To learn more:
 
-- Check out the `examples <examples/index>`_ to see complete examples of how to use PyACP.
-- The `how-to guides <howto/index>`_ provide instructions on how to perform specific tasks.
-- The `API reference <api/index>`_ provides detailed information on all available classes and methods.
+- Check out the :ref:`examples <ref_examples>` to see complete examples of how to use PyACP.
+- The :ref:`how-to guides <howto>` provide instructions on how to perform specific tasks.
+- The :ref:`API reference <api_reference>` provides detailed information on all available classes and methods.
 
 .. testcode::
     :hide:

--- a/doc/source/user_guide/concepts/index.rst
+++ b/doc/source/user_guide/concepts/index.rst
@@ -1,3 +1,5 @@
+.. _concepts:
+
 Concepts
 --------
 

--- a/doc/source/user_guide/howto/index.rst
+++ b/doc/source/user_guide/howto/index.rst
@@ -1,3 +1,5 @@
+.. _howto:
+
 How-to guides
 -------------
 


### PR DESCRIPTION
The links were using explicit (relative) paths, which were
outdated. This PR changes the links to use the `:ref:` directive
instead, which is more robust.