### PR TITLE
Add CI tests with 'direct' launch mode

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -118,6 +118,39 @@ jobs:
           dev-mode: ${{ github.ref != 'refs/heads/main' }}
           extra-targets: "plotting"
 
+  testing-direct-launch:
+    name: Testing with direct launch mode
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Login in Github Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Python version is determined by the base image
+      - name: Build docker image
+        run: docker build -t test_runner -f dockerfiles/DirectLaunchTest.Dockerfile .
+      - name: Run tests
+        run: |
+          docker run \
+          --mount type=bind,source="$(pwd)",target=/home/container/pyacp \
+          -u $(id -u):$(id -g) \
+          -e ANSYSLMD_LICENSE_FILE=$ANSYSLMD_LICENSE_FILE \
+          test_runner
+        env:
+          ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: coverage.xml
+          flags: 'direct-launch,server-latest'
+
   testing-minimum-deps:
     name: Testing with minimum dependencies
     runs-on: ubuntu-latest
@@ -513,7 +546,7 @@ jobs:
   build:
     name: Build library
     runs-on: ubuntu-latest
-    needs: [code-style, testing, testing-minimum-deps, doc-style, docs, build-wheelhouse, doctest] # TODO: add check-vulnerabilities once we know it works on main
+    needs: [code-style, testing, testing-minimum-deps, testing-direct-launch, doc-style, docs, build-wheelhouse, doctest] # TODO: add check-vulnerabilities once we know it works on main
     timeout-minutes: 30
     steps:
       - name: Build library source and wheel artifacts

--- a/dockerfiles/DirectLaunchTest.Dockerfile
+++ b/dockerfiles/DirectLaunchTest.Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+
+ARG BASE_IMAGE=ghcr.io/ansys/acp:latest
+
+FROM $BASE_IMAGE
+
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    python3-venv \
+    pipx \
+    libxrender1 \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+
+USER container
+
+RUN pipx install poetry
+
+ENV PATH="$PATH:/home/container/.local/bin"
+
+# COPY --chown=container:container . /home/container/pyacp
+
+WORKDIR /home/container/pyacp
+
+# Make /home/container writable to any user
+RUN chmod -R 777 /home/container/
+
+COPY --chmod=755 <<EOF /home/container/install_and_run_tests.sh
+#!/usr/bin/bash
+poetry install --with=dev,test --all-extras
+poetry run pytest --cov=ansys.acp.core --cov-report=term --cov-report=xml --cov-report=html --server-bin=/usr/ansys_inc/acp/acp_grpcserver "\$@"
+EOF
+
+ENTRYPOINT ["/home/container/install_and_run_tests.sh"]
+CMD ["tests/unittests"]

--- a/dockerfiles/DirectLaunchTest.Dockerfile.dockerignore
+++ b/dockerfiles/DirectLaunchTest.Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+.github
+dev_utils
+doc
+docker-compose
+dockerfiles
+__pycache__

--- a/tests/unittests/test_cad_geometry.py
+++ b/tests/unittests/test_cad_geometry.py
@@ -90,7 +90,7 @@ class TestCADGeometry(NoLockedMixin, TreeObjectTester):
     @staticmethod
     def test_refresh_inexistent_raises(tree_object):
         """Test refreshing the geometry from an inexistent file."""
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises((FileNotFoundError, RuntimeError)):
             tree_object.refresh("inexistent_file")
 
     @staticmethod

--- a/tests/unittests/test_imported_solid_model.py
+++ b/tests/unittests/test_imported_solid_model.py
@@ -238,7 +238,7 @@ def test_refresh_inexistent_path(parent_object, external_path):
     assume(not pathlib.Path(external_path).exists())
     model = parent_object
     imported_solid_model = model.create_imported_solid_model()
-    with pytest.raises((OSError, ValueError)):
+    with pytest.raises((OSError, ValueError, RuntimeError)):
         imported_solid_model.refresh(external_path)
 
 


### PR DESCRIPTION
Add a Dockerfile which can be used to run the tests with the 'direct' launch mode:
- the ACP image is used as a base image
- the PyACP code is bind-mounted into the container
- the container executes 'poetry install' and 'poetry run pytest' with the appropriate arguments

Note that the Python version is determined by the ACP base image. This means it is not completely trivial to test with different Python versions.