### PR TITLE
Doc: remove beta note from the main doc page

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,12 +15,6 @@
 PyACP
 -----
 
-.. note::
-
-    PyACP is currently released as a beta version. This means that the API may
-    change in future releases. We encourage you to try PyACP and provide us with
-    feedback.
-
 PyACP enables modelling continuous-fiber composite structures from within your
 Python environment. It provides access to the features of Ansys Composite
 PrepPost (ACP) through a Python interface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,13 @@ include = ["src/**/docker-compose.yaml"]
 
 # Less than critical but helpful
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering",
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
Remove the note that PyACP is in beta from the main documentation page.

Switch the trove classifier to indicate that PyACP is stable.

Closes #687.