### PR TITLE
Fix: disable 'price' on 'ModelElementalData'

### DIFF
--- a/examples/modeling_features/031-imported-solid-model.py
+++ b/examples/modeling_features/031-imported-solid-model.py
@@ -58,7 +58,7 @@ import pyvista
 from ansys.acp.core import ElementTechnology, LayupMappingRosetteSelectionMethod, launch_acp
 from ansys.acp.core.extras import ExampleKeys, get_example_file
 
-# sphinx_gallery_thumbnail_number = 4
+# sphinx_gallery_thumbnail_number = 5
 
 
 # %%
@@ -124,6 +124,12 @@ imported_solid_model.create_layup_mapping_object(
 
 model.update()
 model.solid_mesh.to_pyvista().plot(show_edges=True)
+
+# %%
+# Show the mass of the solid model elements
+mass_data = model.elemental_data.mass
+assert mass_data is not None
+mass_data.get_pyvista_mesh(mesh=model.solid_mesh).plot(show_edges=True)
 
 # %%
 # Add other mapping objects

--- a/src/ansys/acp/core/_tree_objects/model.py
+++ b/src/ansys/acp/core/_tree_objects/model.py
@@ -187,7 +187,13 @@ class ModelElementalData(ElementalData):
     thickness: ScalarData[np.float64] | None = None
     relative_thickness_correction: ScalarData[np.float64] | None = None
     area: ScalarData[np.float64] | None = None
-    price: ScalarData[np.float64] | None = None
+    # Retrieving the 'price' can crash the server if the model contains void
+    # analysis plies (on an imported solid model).
+    # This is fixed in the backend for 2025R2, but for now we simply comment
+    # out the property. In this way, the other properties can still be accessed,
+    # and we can avoid the crash.
+    # See https://github.com/ansys/pyacp/issues/717
+    # price: ScalarData[np.float64] | None = None
     volume: ScalarData[np.float64] | None = None
     mass: ScalarData[np.float64] | None = None
     offset: ScalarData[np.float64] | None = None

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -178,7 +178,7 @@ def test_elemental_data(minimal_complete_model):
     numpy.testing.assert_allclose(data.thickness.values, np.array([1e-4]))
     numpy.testing.assert_allclose(data.relative_thickness_correction.values, np.array([1.0]))
     numpy.testing.assert_allclose(data.area.values, np.array([9e4]))
-    numpy.testing.assert_allclose(data.price.values, np.array([0.0]))
+    # numpy.testing.assert_allclose(data.price.values, np.array([0.0])) # disabled due to issue #717.
     numpy.testing.assert_allclose(data.volume.values, np.array([9.0]))
     numpy.testing.assert_allclose(data.mass.values, np.array([7.065e-08]))
     numpy.testing.assert_allclose(data.offset.values, np.array([5e-5]))


### PR DESCRIPTION
Comment out the `price` attribute on the `ModelElementalData`, as a workaround to #717.

Add a mass plot to the imported solid model example.

Closes #717.
Follow-up tasks tracked by #720.