### PR TITLE
Docs: add experimental warning to CDB to PyMechanical example

### DIFF
--- a/examples/workflows/06-cdb-to-pymechanical-workflow.py
+++ b/examples/workflows/06-cdb-to-pymechanical-workflow.py
@@ -32,6 +32,11 @@ This example shows how to define a composite lay-up in PyACP based on a mesh
 from a CDB file, import the model into PyMechanical for defining the load and
 boundary conditions, and run a failure analysis with PyDPF Composites.
 
+.. warning::
+
+    The PyACP / PyMechanical integration is still experimental. Refer to the
+    :ref:`limitations section <limitations>` for more information.
+
 """
 
 


### PR DESCRIPTION
Add the warning that PyMechanical integration is experimental to the CDB to PyMechanical example, since it uses the helper function to load the ACPCompositeDefinitions.h5 into Mechanical.

Closes #735 