### PR TITLE
Added danger hint when using windows paths

### DIFF
--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -83,9 +83,9 @@ The following example imports a CDB file.
 See :class:`.FeFormat` for a list of supported FE formats. Check out the
 :ref:`input_file_for_pyacp` section to see how input files can be created.
 
-.. warning::
+.. danger::
     When working on Windows, be careful of possible **escape sequences** in paths that could result in errors.
-    To avoid issues, make sure to quote the backslashes in your path or use a *raw string literal* by prefixing your string with *r*,
+    To avoid issues, make sure to quote the backslashes in your path or use a *raw string literal* by prefixing your string with **r**,
     like ``model = acp.import_model(r"path\to\your\model.acph5")``.
 
 

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -84,8 +84,10 @@ See :class:`.FeFormat` for a list of supported FE formats. Check out the
 :ref:`input_file_for_pyacp` section to see how input files can be created.
 
 .. danger::
-    When working on Windows, be careful of possible **escape sequences** in paths that could result in errors.
-    To avoid issues, make sure to quote the backslashes in your path or use a *raw string literal* by prefixing your string with **r**,
+    When working on Windows, be careful of possible 
+    `escape sequences <https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences>`_ in paths that could result in errors.
+    To avoid issues, make sure to quote the backslashes (by using ``\\``) or use a 
+    `raw string literal <https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals>`_ by prefixing your string with **r**,
     like ``model = acp.import_model(r"path\to\your\model.acph5")``.
 
 

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -83,6 +83,11 @@ The following example imports a CDB file.
 See :class:`.FeFormat` for a list of supported FE formats. Check out the
 :ref:`input_file_for_pyacp` section to see how input files can be created.
 
+.. warning::
+    When working on Windows, be careful of possible **escape sequences** in paths that could result in errors.
+    To avoid issues, make sure to quote the backslashes in your path or use a *raw string literal* by prefixing your string with *r*,
+    like ``model = acp.import_model(r"path\to\your\model.acph5")``.
+
 
 Start modelling
 ~~~~~~~~~~~~~~~

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -84,8 +84,8 @@ See :class:`.FeFormat` for a list of supported FE formats. Check out the
 :ref:`input_file_for_pyacp` section to see how input files can be created.
 
 .. danger::
-    When working on Windows, be careful of possible 
-    `escape sequences <https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences>`_ in paths that could result in errors.
+    When working on Windows, be careful of backslashes in paths: These may correspond to
+    `escape sequences <https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences>`_, resulting in errors.
     To avoid issues, make sure to quote the backslashes (by using ``\\``) or use a 
     `raw string literal <https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals>`_ by prefixing your string with **r**,
     like ``model = acp.import_model(r"path\to\your\model.acph5")``.


### PR DESCRIPTION
Added danger section in the **Getting started** section of the documentation when using paths in Windows with "\\" that might generate escape sequences in the string if not treated properly. See related Issue #739 .