### PR TITLE
Added exit call to avoid problems when building documentation

### DIFF
--- a/examples/use_cases/01-optimizing-ply-angles.py
+++ b/examples/use_cases/01-optimizing-ply-angles.py
@@ -493,3 +493,6 @@ ax.axis("off")  # Hide the x and y axes
 
 plt.tight_layout()
 plt.show()
+
+# Close MAPDL instance
+mapdl.exit()

--- a/examples/workflows/01-pymapdl-workflow.py
+++ b/examples/workflows/01-pymapdl-workflow.py
@@ -270,3 +270,6 @@ irf_field.plot()
 # %%
 # Release the composite model to close the open streams to the result file.
 composite_model = None  # type: ignore
+
+# Close MAPDL instance
+mapdl.exit()

--- a/examples/workflows/02-advanced-pymapdl-workflow.py
+++ b/examples/workflows/02-advanced-pymapdl-workflow.py
@@ -390,3 +390,6 @@ output_all_elements = composite_model.evaluate_failure_criteria(cfc)
 # Query and plot the results.
 irf_field = output_all_elements.get_field({"failure_label": FailureOutput.FAILURE_VALUE})
 irf_field.plot()
+
+# Close MAPDL instance
+mapdl.exit()

--- a/examples/workflows/05-pymechanical-to-cdb-workflow.py
+++ b/examples/workflows/05-pymechanical-to-cdb-workflow.py
@@ -314,3 +314,6 @@ irf_field = output_all_elements.get_field(
     {"failure_label": pydpf_composites.constants.FailureOutput.FAILURE_VALUE}
 )
 irf_field.plot()
+
+# Close MAPDL instance
+mapdl.exit()

--- a/src/ansys/acp/core/extras/example_helpers.py
+++ b/src/ansys/acp/core/extras/example_helpers.py
@@ -264,3 +264,6 @@ def _run_analysis(model: "Model") -> None:
         # %%
         # Release composite model to close open streams to result file.
         composite_model = None  # type: ignore
+
+        # Close MAPDL instance
+        mapdl.exit()


### PR DESCRIPTION
This PR adds an explicit `exit` call to the mapdl instance in the python documentation examples in order for it to not fail when building the documentation using the provided `make.bat`.