### PR TITLE
Set LIBGL_ALWAYS_SOFTWARE env variable in doc build

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -411,6 +411,7 @@ jobs:
           IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
           PYACP_DOC_SKIP_GALLERY: "true"
           PYACP_DOC_SKIP_API: "true"
+          LIBGL_ALWAYS_SOFTWARE: 1
 
   docs:
     name: Build Documentation
@@ -504,6 +505,7 @@ jobs:
           SPHINXOPT_NITPICKY: ${{ matrix.build_type == 'quick' && ' ' || '-n' }}
           PYACP_DOC_SKIP_GALLERY: ${{ matrix.build_type == 'quick' && 'true' || 'false' }}
           PYACP_DOC_SKIP_API: ${{ matrix.build_type == 'quick' && 'true' || 'false' }}
+          LIBGL_ALWAYS_SOFTWARE: 1
 
       - name: Stop and clean up MAPDL and DPF servers
         run: |
@@ -534,6 +536,8 @@ jobs:
       - name: Build PDF Documentation
         run: xvfb-run poetry run make -C doc pdf
         if: ${{ matrix.build_type == 'full' }}
+        env:
+          LIBGL_ALWAYS_SOFTWARE: 1
 
       - name: Upload PDF Documentation
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Gets rid of the MESA errors [1] which appeared since `ubuntu-latest` switched to 24.04.

[1] errors like the following. They seemed to ultimately not cause any build failure, but pollute the output.
```
MESA: error: ZINK: vkCreateInstance failed (VK_ERROR_INCOMPATIBLE_DRIVER)
glx: failed to create drisw screen
```