### PR TITLE
Update pre-commit hooks, use poetry 2.x

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Install library, with all optional groups
         run: |
           pip install -U pip
-          pip install 'poetry!=1.7.0'
-          poetry install --with dev,test --all-extras
+          pip install poetry
+          poetry install --all-groups --all-extras
 
       - name: Build API package from custom branch
         if: "${{ env.API_BRANCH != '' }}"
@@ -357,7 +357,7 @@ jobs:
         run: |
           pip install -U pip
           pip install 'poetry!=1.7.0'
-          poetry install --with test,dev --all-extras
+          poetry install --all-groups --all-extras
 
       - name: Build API package from custom branch
         if: "${{ env.API_BRANCH != '' }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: [--py310-plus]
 
   - repo: https://github.com/psf/black
-    rev: "24.10.0" # when changed, also update the version in blacken-docs
+    rev: "25.1.0" # when changed, also update the version in blacken-docs
     hooks:
       - id: black
 
@@ -14,27 +14,27 @@ repos:
     rev: 1.19.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==24.10.0]
+        additional_dependencies: [black==25.1.0]
 
   - repo: https://github.com/pycqa/isort
-    rev: "5.13.2"
+    rev: "6.0.0"
     hooks:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: "7.1.1"
+    rev: "7.1.2"
     hooks:
       - id: flake8
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies: ["tomli"] # needed to parse pyproject.toml
         exclude: '^poetry\.lock|pyproject\.toml|.*\.svg$'
 
   - repo: https://github.com/python-poetry/poetry/
-    rev: "1.8.0"
+    rev: "2.1.1"
     hooks:
       - id: poetry-check
         name: "poetry: check pyproject.toml syntax"
@@ -51,7 +51,7 @@ repos:
       exclude: "^(tests/)|(type_checks/)|(examples/)"
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.8.0
+    rev: 0.8.1
     hooks:
       - id: nbstripout
         args:
@@ -61,7 +61,7 @@ repos:
           ]
 
   - repo: https://github.com/ansys/pre-commit-hooks
-    rev: v0.4.3
+    rev: v0.5.1
     hooks:
     - id: add-license-headers
       args: ["--start_year", "2022"]

--- a/README.rst
+++ b/README.rst
@@ -103,13 +103,14 @@ You will need to follow these steps:
         git clone https://github.com/ansys/pyacp
         cd pyacp
 
-2.  Make sure you have the latest version of poetry:
+2.  Make sure you have the latest version of poetry and its shell plugin:
 
     .. code-block:: bash
 
         python -m pip install pipx
         pipx ensurepath
         pipx install poetry
+        pipx inject poetry poetry-plugin-shell
 
     .. note::
 
@@ -120,7 +121,7 @@ You will need to follow these steps:
 
     .. code-block:: bash
 
-        poetry install --with dev,test --all-extras
+        poetry install --all-groups --all-extras
 
     This step installs PyACP in an editable mode (no build step is needed, no re-install when changing the code).
 

--- a/dockerfiles/DirectLaunchTest.Dockerfile
+++ b/dockerfiles/DirectLaunchTest.Dockerfile
@@ -33,7 +33,7 @@ RUN chmod -R 777 /home/container/
 
 COPY --chmod=755 <<EOF /home/container/install_and_run_tests.sh
 #!/usr/bin/bash
-poetry install --with=dev,test --all-extras
+poetry install --all-groups --all-extras
 poetry run pytest --cov=ansys.acp.core --cov-report=term --cov-report=xml --cov-report=html --server-bin=/usr/ansys_inc/acp/acp_grpcserver "\$@"
 EOF
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ add-ignore = "D201,D202,D203,D204,D105" # blank line rules before / after docstr
 
 [tool.codespell]
 skip = '*.cdb,*.dat'
-ignore-words-list = 'ans,uptodate,notuptodate,eyt'
+ignore-words-list = 'ans,uptodate,notuptodate,eyt,abd'
 quiet-level = 3
 
 [tool.mypy]


### PR DESCRIPTION
Update the pre-commit hooks with `pre-commit autoupdate`.

Update the poetry version to 2.x, and adapt the CI commands and README instructions.