### PR TITLE
Use main branch for logo link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://github.com/ansys/pyacp/blob/feat/pyacp_logo/doc/source/_static/pyacp.svg
+.. image:: https://raw.githubusercontent.com/ansys/pyacp/refs/heads/main/doc/source/_static/pyacp.svg
     :width: 400
     :alt: PyACP Logo
     :align: center


### PR DESCRIPTION
- Use `main` branch for the PyACP logo link
- Use the 'raw' content (raw.githubusercontent.com link) instead of the github.com link, since the latter relies on Github's logic to show only the SVG itself. This doesn't work in all contexts (e.g. on PyPI).

Closes #763.