### PR TITLE
Always orphan the gh-pages branch

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -588,7 +588,6 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
-          force-orphan: false
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
 


### PR DESCRIPTION
Remove the `force-orphan: false` option in the "Upload dev documentation" job in the CI/CD workflow.
The option caused previous commits to `gh-pages` to be preserved, whereas now only the latest commit is preserved.

Closes #758 