### PR TITLE
Show edges  in getting started

### DIFF
--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -162,7 +162,7 @@ Many PyACP objects provide data which can be plotted. For example, to show the m
 
 .. testcode::
 
-    plate_cdb_model.mesh.to_pyvista().plot()
+    plate_cdb_model.mesh.to_pyvista().plot(show_edges=True)
 
 Or to show the thickness of a modeling ply or fiber directions:
 

--- a/tests/unittests/test_imported_solid_model.py
+++ b/tests/unittests/test_imported_solid_model.py
@@ -244,7 +244,7 @@ def test_refresh_inexistent_path(parent_object, external_path):
             os.lstat(path)
         except FileNotFoundError:
             return True
-        except OSError:
+        except (OSError, ValueError):
             return False
         return True
 


### PR DESCRIPTION
Use `show_edges=True` in the getting started 'plot the mesh' example, so that is
clear the plotted plate represents the mesh.

25R2 hardening item 34.