### PR TITLE
Explicitly set the plot theme in all examples

### DIFF
--- a/doc/source/api/example_helpers.rst
+++ b/doc/source/api/example_helpers.rst
@@ -8,3 +8,4 @@ Example helpers
 
     ExampleKeys
     get_example_file
+    set_plot_theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,6 +12,8 @@ from pyvista.plotting.utilities.sphinx_gallery import DynamicScraper
 from sphinx.builders.latex import LaTeXBuilder
 import sphinx.util.inspect
 
+from ansys.acp.core import extras
+
 
 def _signature(
     subject,
@@ -130,12 +132,6 @@ jinja_contexts = {
     "conditional_skip": {"skip_api": SKIP_API, "skip_gallery": SKIP_GALLERY},
 }
 
-
-# PyMAPDL and PyDPF override the default PyVista theme, so we need to import it
-# here to have a chance of re-setting it.
-import ansys.mapdl.core  # isort:skip
-import ansys.dpf.core  # isort:skip # noqa: F401
-
 # Manage errors
 pyvista.set_error_output_file("errors.txt")
 
@@ -145,8 +141,8 @@ pyvista.OFF_SCREEN = True
 # necessary when building the sphinx gallery
 pyvista.BUILDING_GALLERY = True
 
-pyvista.global_theme = pyvista.themes.DocumentTheme()
-pyvista.global_theme.cmap = "viridis_r"
+# Set the plot theme to be used in the documentation
+extras.set_plot_theme()
 
 # ignore the matplotlib warning when .show() is called
 warnings.filterwarnings("ignore", category=UserWarning, message=".*is non-interactive.*")

--- a/examples/modeling_features/001-materials.py
+++ b/examples/modeling_features/001-materials.py
@@ -49,7 +49,7 @@ import tempfile
 # %%
 # Import the PyACP dependencies.
 from ansys.acp.core import FabricWithAngle, Lamina, PlyType, SymmetryType, launch_acp
-from ansys.acp.core.extras import ExampleKeys, get_example_file
+from ansys.acp.core.extras import ExampleKeys, get_example_file, set_plot_theme
 from ansys.acp.core.material_property_sets import (
     ConstantEngineeringConstants,
     ConstantStrainLimits,
@@ -58,6 +58,10 @@ from ansys.acp.core.material_property_sets import (
 
 # sphinx_gallery_thumbnail_path = '_static/gallery_thumbnails/sphx_glr_001-materials_thumb.png'
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start ACP and load the model

--- a/examples/modeling_features/002-rosettes-ply-directions.py
+++ b/examples/modeling_features/002-rosettes-ply-directions.py
@@ -51,9 +51,14 @@ from ansys.acp.core import (
     get_directions_plotter,
     launch_acp,
 )
-from ansys.acp.core.extras import ExampleKeys, get_example_file
+from ansys.acp.core.extras import ExampleKeys, get_example_file, set_plot_theme
 
 # sphinx_gallery_thumbnail_number = 4
+
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start ACP and load the model

--- a/examples/modeling_features/003-simple-selection-rules.py
+++ b/examples/modeling_features/003-simple-selection-rules.py
@@ -45,10 +45,14 @@ import tempfile
 # %%
 # Import the PyACP dependencies.
 from ansys.acp.core import LinkedSelectionRule, launch_acp
-from ansys.acp.core.extras import ExampleKeys, get_example_file
+from ansys.acp.core.extras import ExampleKeys, get_example_file, set_plot_theme
 
 # sphinx_gallery_thumbnail_number = -1
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start ACP and load the model

--- a/examples/modeling_features/004-advanced-selection-rules.py
+++ b/examples/modeling_features/004-advanced-selection-rules.py
@@ -56,10 +56,14 @@ from ansys.acp.core import (
     PhysicalDimension,
     launch_acp,
 )
-from ansys.acp.core.extras import ExampleKeys, get_example_file
+from ansys.acp.core.extras import ExampleKeys, get_example_file, set_plot_theme
 
 # sphinx_gallery_thumbnail_number = 5
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start ACP and load the model

--- a/examples/modeling_features/005-ply-direction-lookup-table.py
+++ b/examples/modeling_features/005-ply-direction-lookup-table.py
@@ -53,7 +53,12 @@ from ansys.acp.core import (
     get_directions_plotter,
     launch_acp,
 )
-from ansys.acp.core.extras import ExampleKeys, get_example_file
+from ansys.acp.core.extras import ExampleKeys, get_example_file, set_plot_theme
+
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start ACP and load the model

--- a/examples/modeling_features/006-layup-thickness-definitions.py
+++ b/examples/modeling_features/006-layup-thickness-definitions.py
@@ -46,10 +46,19 @@ import pyvista
 # %%
 # Import the PyACP dependencies.
 from ansys.acp.core import PhysicalDimension, ThicknessType, launch_acp
-from ansys.acp.core.extras import FLAT_PLATE_SOLID_CAMERA, ExampleKeys, get_example_file
+from ansys.acp.core.extras import (
+    FLAT_PLATE_SOLID_CAMERA,
+    ExampleKeys,
+    get_example_file,
+    set_plot_theme,
+)
 
 # sphinx_gallery_thumbnail_number = 2
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start ACP and load the model

--- a/examples/modeling_features/007-sensor.py
+++ b/examples/modeling_features/007-sensor.py
@@ -45,9 +45,19 @@ import pyvista
 # %%
 # Import the PyACP dependencies.
 from ansys.acp.core import SensorType, UnitSystemType, launch_acp
-from ansys.acp.core.extras import RACE_CARE_NOSE_CAMERA_METER, ExampleKeys, get_example_file
+from ansys.acp.core.extras import (
+    RACE_CARE_NOSE_CAMERA_METER,
+    ExampleKeys,
+    get_example_file,
+    set_plot_theme,
+)
 
 # sphinx_gallery_thumbnail_number = 2
+
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 
 # %%

--- a/examples/modeling_features/010-sandwich-panel-layup.py
+++ b/examples/modeling_features/010-sandwich-panel-layup.py
@@ -48,11 +48,15 @@ from ansys.acp.core import (
     launch_acp,
     print_model,
 )
-from ansys.acp.core.extras import ExampleKeys, get_example_file
+from ansys.acp.core.extras import ExampleKeys, get_example_file, set_plot_theme
 from ansys.acp.core.material_property_sets import ConstantEngineeringConstants, ConstantStrainLimits
 
 # sphinx_gallery_thumbnail_number = 2
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start ACP and load the model

--- a/examples/modeling_features/020-solid_model.py
+++ b/examples/modeling_features/020-solid_model.py
@@ -52,10 +52,19 @@ from ansys.acp.core import (
     get_directions_plotter,
     launch_acp,
 )
-from ansys.acp.core.extras import FLAT_PLATE_SOLID_CAMERA, ExampleKeys, get_example_file
+from ansys.acp.core.extras import (
+    FLAT_PLATE_SOLID_CAMERA,
+    ExampleKeys,
+    get_example_file,
+    set_plot_theme,
+)
 
 # sphinx_gallery_thumbnail_number = 4
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Load a minimal model

--- a/examples/modeling_features/030-imported-plies.py
+++ b/examples/modeling_features/030-imported-plies.py
@@ -59,11 +59,15 @@ import pyvista
 # %%
 # Import the PyACP dependencies.
 from ansys.acp.core import CADGeometry, ImportedPlyOffsetType, PlyType, VirtualGeometry, launch_acp
-from ansys.acp.core.extras import ExampleKeys, get_example_file
+from ansys.acp.core.extras import ExampleKeys, get_example_file, set_plot_theme
 from ansys.acp.core.material_property_sets import ConstantDensity, ConstantEngineeringConstants
 
 # sphinx_gallery_thumbnail_number = 3
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 CAMERA_POSITION = [(0.0436, 0.0102, 0.0193), (0.0111, 0.0035, 0.0046), (-0.1685, 0.9827, -0.0773)]
 

--- a/examples/modeling_features/031-imported-solid-model.py
+++ b/examples/modeling_features/031-imported-solid-model.py
@@ -56,10 +56,14 @@ import pyvista
 # %%
 # Import the PyACP dependencies.
 from ansys.acp.core import ElementTechnology, LayupMappingRosetteSelectionMethod, launch_acp
-from ansys.acp.core.extras import ExampleKeys, get_example_file
+from ansys.acp.core.extras import ExampleKeys, get_example_file, set_plot_theme
 
 # sphinx_gallery_thumbnail_number = 5
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start ACP and load the model

--- a/examples/modeling_features/050-composite_cae_h5.py
+++ b/examples/modeling_features/050-composite_cae_h5.py
@@ -62,10 +62,15 @@ from ansys.acp.core.extras import (
     FLAT_PLATE_SOLID_CAMERA,
     ExampleKeys,
     get_example_file,
+    set_plot_theme,
 )
 
 # sphinx_gallery_thumbnail_number = 2
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start ACP and load the model

--- a/examples/use_cases/01-optimizing-ply-angles.py
+++ b/examples/use_cases/01-optimizing-ply-angles.py
@@ -61,12 +61,16 @@ from scipy.optimize import minimize
 # %%
 # Import Ansys libraries
 import ansys.acp.core as pyacp
-from ansys.acp.core.extras import ExampleKeys, get_example_file
+from ansys.acp.core.extras import ExampleKeys, get_example_file, set_plot_theme
 import ansys.dpf.composites as pydpf_composites
 import ansys.mapdl.core as pymapdl
 
 # sphinx_gallery_thumbnail_number = -2
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Launch the PyACP server.

--- a/examples/workflows/01-pymapdl-workflow.py
+++ b/examples/workflows/01-pymapdl-workflow.py
@@ -59,10 +59,14 @@ from ansys.acp.core import (
     material_property_sets,
     print_model,
 )
-from ansys.acp.core.extras import ExampleKeys, get_example_file
+from ansys.acp.core.extras import ExampleKeys, get_example_file, set_plot_theme
 
 # sphinx_gallery_thumbnail_number = 3
 
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Launch PyACP

--- a/examples/workflows/02-advanced-pymapdl-workflow.py
+++ b/examples/workflows/02-advanced-pymapdl-workflow.py
@@ -51,8 +51,14 @@ import pyvista
 # %%
 # Import the Ansys libraries.
 import ansys.acp.core as pyacp
+from ansys.acp.core.extras import set_plot_theme
 
 # sphinx_gallery_thumbnail_number = -1
+
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 
 # %%

--- a/examples/workflows/03-pymechanical-shell-workflow.py
+++ b/examples/workflows/03-pymechanical-shell-workflow.py
@@ -64,10 +64,16 @@ import textwrap
 
 # isort: off
 import ansys.acp.core as pyacp
+from ansys.acp.core.extras import set_plot_theme
 import ansys.dpf.composites as pydpf_composites
 import ansys.mechanical.core as pymechanical
 
 # sphinx_gallery_thumbnail_path = '_static/gallery_thumbnails/sphx_glr_03-pymechanical-shell-workflow_thumb.png'
+
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start the ACP, Mechanical, and DPF servers. We use a ``ThreadPoolExecutor``

--- a/examples/workflows/04-pymechanical-solid-workflow.py
+++ b/examples/workflows/04-pymechanical-solid-workflow.py
@@ -67,10 +67,16 @@ import textwrap
 # isort: off
 
 import ansys.acp.core as pyacp
+from ansys.acp.core.extras import set_plot_theme
 import ansys.dpf.composites as pydpf_composites
 import ansys.mechanical.core as pymechanical
 
 # sphinx_gallery_thumbnail_path = '_static/gallery_thumbnails/sphx_glr_04-pymechanical-solid-workflow_thumb.png'
+
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start the ACP, Mechanical, and DPF servers. We use a ``ThreadPoolExecutor``

--- a/examples/workflows/05-pymechanical-to-cdb-workflow.py
+++ b/examples/workflows/05-pymechanical-to-cdb-workflow.py
@@ -56,12 +56,18 @@ import textwrap
 
 # isort: off
 import ansys.acp.core as pyacp
+from ansys.acp.core.extras import set_plot_theme
 import ansys.dpf.core as pydpf_core
 import ansys.dpf.composites as pydpf_composites
 import ansys.mapdl.core as pymapdl
 import ansys.mechanical.core as pymechanical
 
 # sphinx_gallery_thumbnail_path = '_static/gallery_thumbnails/sphx_glr_05-pymechanical-to-cdb-workflow_thumb.png'
+
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start the ACP, Mechanical, and DPF servers. We use a ``ThreadPoolExecutor``

--- a/examples/workflows/06-cdb-to-pymechanical-workflow.py
+++ b/examples/workflows/06-cdb-to-pymechanical-workflow.py
@@ -58,11 +58,17 @@ import textwrap
 
 # isort: off
 import ansys.acp.core as pyacp
+from ansys.acp.core.extras import set_plot_theme
 from ansys.acp.core.extras import example_helpers
 import ansys.dpf.composites as pydpf_composites
 import ansys.mechanical.core as pymechanical
 
 # sphinx_gallery_thumbnail_path = '_static/gallery_thumbnails/sphx_glr_06-cdb-to-pymechanical-workflow_thumb.png'
+
+# %%
+# Set the plot theme for the example. This is optional, and ensures that you get the
+# same plot style (theme, color map, etc.) as in the online documentation.
+set_plot_theme()
 
 # %%
 # Start the ACP, Mechanical, and DPF servers. We use a ``ThreadPoolExecutor``

--- a/src/ansys/acp/core/extras/__init__.py
+++ b/src/ansys/acp/core/extras/__init__.py
@@ -27,12 +27,14 @@ from ansys.acp.core.extras.example_helpers import (
     RACE_CARE_NOSE_CAMERA_METER,
     ExampleKeys,
     get_example_file,
+    set_plot_theme,
 )
 
 __all__ = [
     "ExampleKeys",
-    "get_example_file",
     "FLAT_PLATE_SHELL_CAMERA",
     "FLAT_PLATE_SOLID_CAMERA",
+    "get_example_file",
     "RACE_CARE_NOSE_CAMERA_METER",
+    "set_plot_theme",
 ]

--- a/src/ansys/acp/core/extras/example_helpers.py
+++ b/src/ansys/acp/core/extras/example_helpers.py
@@ -39,6 +39,7 @@ __all__ = [
     "FLAT_PLATE_SHELL_CAMERA",
     "FLAT_PLATE_SOLID_CAMERA",
     "RACE_CARE_NOSE_CAMERA_METER",
+    "set_plot_theme",
 ]
 
 from typing import TYPE_CHECKING
@@ -275,3 +276,20 @@ def _run_analysis(model: "Model") -> None:
 
         # Close MAPDL instance
         mapdl.exit()
+
+
+def set_plot_theme() -> None:
+    """Set the theme options used in the examples.
+
+    This function sets the default plotting theme options to the ones used
+    in the examples. You can call this function to ensure the plots are using
+    the same theme (color maps etc.) as the rendered online documentation.
+    """
+    # PyMAPDL and PyDPF override the default PyVista theme, so we need to import it
+    # here to have a chance of re-setting it.
+    import ansys.mapdl.core  # isort:skip
+    import ansys.dpf.core  # isort:skip # noqa: F401
+    import pyvista
+
+    pyvista.global_theme = pyvista.themes.DocumentTheme()
+    pyvista.global_theme.cmap = "viridis_r"

--- a/src/ansys/acp/core/extras/example_helpers.py
+++ b/src/ansys/acp/core/extras/example_helpers.py
@@ -291,5 +291,9 @@ def set_plot_theme() -> None:
     import ansys.dpf.core  # isort:skip # noqa: F401
     import pyvista
 
+    # Use the PyVista 'document' theme (white background, black text, etc.),
+    # except with the 'reversed' viridis color map. This is more suited to
+    # e.g. thickness plots, because the thicker parts of the model will be
+    # in dark colors, instead of light colors.
     pyvista.global_theme = pyvista.themes.DocumentTheme()
     pyvista.global_theme.cmap = "viridis_r"


### PR DESCRIPTION
Add a function `set_plot_theme` which sets the plot theme + default colormap used in the examples.

Call the function at the start of each example, to ensure the user gets the same plots.

25R2 hardening items 37, 38, 52.