### PR TITLE
Fix indentation errors in examples

### DIFF
--- a/examples/modeling_features/006-layup-thickness-definitions.py
+++ b/examples/modeling_features/006-layup-thickness-definitions.py
@@ -72,6 +72,7 @@ model = acp.import_model(input_file)
 print(model.unit_system)
 
 
+# %%
 # Plot the nominal ply thickness.
 modeling_ply = model.modeling_groups["modeling_group"].modeling_plies["ply"]
 model.update()

--- a/examples/modeling_features/007-sensor.py
+++ b/examples/modeling_features/007-sensor.py
@@ -65,14 +65,15 @@ acph5_input_file = get_example_file(ExampleKeys.RACE_CAR_NOSE_ACPH5, WORKING_DIR
 acp = launch_acp()
 
 # %%
-# Load the model from the input file which contains
-# a formula 1 front wing with layup. The plot shows the total
-# laminate thickness per element.
+# Load the model from the input file which contains a formula 1 front
+# wing with layup.
 model = acp.import_model(acph5_input_file)
 model.unit_system = UnitSystemType.SI
 print(model.unit_system)
 model.update()
 
+# %%
+# The plot shows the total laminate thickness per element.
 thickness_data = model.elemental_data.thickness
 if thickness_data is not None:
     plotter = pyvista.Plotter()
@@ -175,6 +176,7 @@ print_measures(sensor_by_ply)
 plotter = pyvista.Plotter()
 for ply in modeling_plies:
     plotter.add_mesh(ply.mesh.to_pyvista(), show_edges=False, opacity=1, color="turquoise")
+
 plotter.add_mesh(model.mesh.to_pyvista(), show_edges=False, opacity=0.2)
 plotter.camera_position = RACE_CARE_NOSE_CAMERA_METER
 plotter.show()

--- a/examples/modeling_features/030-imported-plies.py
+++ b/examples/modeling_features/030-imported-plies.py
@@ -236,6 +236,7 @@ for imported_ply in [imported_ply_triangle, imported_ply_top]:
     for pp in imported_ply.imported_production_plies.values():
         for ap in pp.imported_analysis_plies.values():
             plotter.add_mesh(ap.solid_mesh.to_pyvista(), show_edges=True, opacity=1)
+
 plotter.add_mesh(mesh=imported_solid_model.solid_mesh.to_pyvista(), show_edges=False, opacity=0.2)
 plotter.show()
 

--- a/examples/use_cases/01-optimizing-ply-angles.py
+++ b/examples/use_cases/01-optimizing-ply-angles.py
@@ -39,6 +39,8 @@ it demonstrates the process of optimizing a composite lay-up with PyACP.
     When copy / pasting the blocks in this example, make sure to use either a Jupyter
     notebook, or an IPython console. The default Python interactive console (prior to
     Python 3.13) does not allow empty lines in indented code.
+    To run the example with the default Python interpreter, download and execute the
+    example script.
 
 """
 

--- a/examples/use_cases/01-optimizing-ply-angles.py
+++ b/examples/use_cases/01-optimizing-ply-angles.py
@@ -33,6 +33,13 @@ reserve factor (IRF) of the composite structure under two load cases.
 The example uses the :py:func:`scipy.optimize.minimize` function to perform the optimization.
 While the procedure itself is not the focus of this example and could be improved,
 it demonstrates the process of optimizing a composite lay-up with PyACP.
+
+.. note::
+
+    When copy / pasting the blocks in this example, make sure to use either a Jupyter
+    notebook, or an IPython console. The default Python interactive console (prior to
+    Python 3.13) does not allow empty lines in indented code.
+
 """
 
 # %%


### PR DESCRIPTION
- Add empty lines at the end of indented blocks 
- Split blocks generating text output and plots into two separate blocks
- Optimization example: add note about using Jupyter or IPython when copy/pasting the code block by block.

25R2 hardening items 4, 42, 45, 57.