### PR TITLE
Add note about missing output in examples

### DIFF
--- a/examples/workflows/03-pymechanical-shell-workflow.py
+++ b/examples/workflows/03-pymechanical-shell-workflow.py
@@ -44,6 +44,12 @@ PyMechanical:
     The PyACP / PyMechanical integration is still experimental. Refer to the
     :ref:`limitations section <limitations>` for more information.
 
+.. note::
+
+    Outputs and plots for this example are not shown in the rendered online
+    documentation. To see the outputs and plots, run the example script or
+    Jupyter notebook locally.
+
 """
 
 # %%

--- a/examples/workflows/04-pymechanical-solid-workflow.py
+++ b/examples/workflows/04-pymechanical-solid-workflow.py
@@ -46,6 +46,12 @@ PyMechanical:
     The PyACP / PyMechanical integration is still experimental. Refer to the
     :ref:`limitations section <limitations>` for more information.
 
+.. note::
+
+    Outputs and plots for this example are not shown in the rendered online
+    documentation. To see the outputs and plots, run the example script or
+    Jupyter notebook locally.
+
 """
 
 # %%

--- a/examples/workflows/05-pymechanical-to-cdb-workflow.py
+++ b/examples/workflows/05-pymechanical-to-cdb-workflow.py
@@ -35,6 +35,12 @@ model, and PyDPF - Composites to post-process the results.
 This workflow does *not* suffer from the limitations of the PyACP to
 PyMechanical integration.
 
+.. note::
+
+    Outputs and plots for this example are not shown in the rendered online
+    documentation. To see the outputs and plots, run the example script or
+    Jupyter notebook locally.
+
 """
 
 

--- a/examples/workflows/06-cdb-to-pymechanical-workflow.py
+++ b/examples/workflows/06-cdb-to-pymechanical-workflow.py
@@ -37,6 +37,12 @@ boundary conditions, and run a failure analysis with PyDPF - Composites.
     The PyACP / PyMechanical integration is still experimental. Refer to the
     :ref:`limitations section <limitations>` for more information.
 
+.. note::
+
+    Outputs and plots for this example are not shown in the rendered online
+    documentation. To see the outputs and plots, run the example script or
+    Jupyter notebook locally.
+
 """
 
 


### PR DESCRIPTION
Add a note to the examples which are not run when generating the documentation in CI, indicating that the online version of the documentation is missing the outputs and plots.

25R2 hardening items 53, 54.