### PR TITLE
Getting started: show fiber direction instead of reference direction

### DIFF
--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -170,7 +170,7 @@ Or to show the thickness of a modeling ply or fiber directions:
 
     modeling_ply.elemental_data.thickness.get_pyvista_mesh(mesh=plate_cdb_model.mesh).plot()
     plotter = pyacp.get_directions_plotter(
-        model=plate_cdb_model, components=[modeling_ply.elemental_data.reference_direction]
+        model=plate_cdb_model, components=[modeling_ply.elemental_data.fiber_direction]
     )
     plotter.show()
 

--- a/examples/modeling_features/031-imported-solid-model.py
+++ b/examples/modeling_features/031-imported-solid-model.py
@@ -95,7 +95,7 @@ model = acp.import_model(input_file)
 #     To avoid this, you can use the ``.extract_surface(nonlinear_subdivision=0)`` call
 #     to extract a linearized surface.
 #     Alternatively, you can use ``.separate_cells().extract_feature_edges()`` to
-#     obtain the edges as a separate PyVista :py:class:`.PolyData` object.
+#     obtain the edges as a separate :py:class:`pyvista.PolyData` object.
 #
 #     For more information, see this PyVista discussion:
 #     https://github.com/pyvista/pyvista/discussions/5777


### PR DESCRIPTION
Plot the `fiber_direction` instead of `reference_direction` in the getting started, to match the text description.

25R2 hardening item 35.