### PR TITLE
Use PyVista headless display action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -386,7 +386,10 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt update
-          sudo apt-get install pandoc xvfb
+          sudo apt-get install pandoc
+
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@48066dd0b79cf46babc16223a1dce3aa4803ec43 # v4.0
 
       - name: Configure Local Product Launcher for ACP
         working-directory: tests/unittests
@@ -405,13 +408,12 @@ jobs:
         run: |
           docker pull $IMAGE_NAME
           docker pull ghcr.io/ansys/tools-filetransfer:latest
-          xvfb-run poetry run make -C doc doctest
+          poetry run make -C doc doctest
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
           IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
           PYACP_DOC_SKIP_GALLERY: "true"
           PYACP_DOC_SKIP_API: "true"
-          LIBGL_ALWAYS_SOFTWARE: 1
 
   docs:
     name: Build Documentation
@@ -448,7 +450,10 @@ jobs:
       - name: Install OS packages
         run: |
           sudo apt update
-          sudo apt-get install pandoc xvfb
+          sudo apt-get install pandoc
+
+      - name: Set up headless display
+        uses: pyvista/setup-headless-display-action@48066dd0b79cf46babc16223a1dce3aa4803ec43 # v4.0
 
       - name: Install library, with dev group
         run: |
@@ -496,7 +501,7 @@ jobs:
 
       - name: Build HTML
         run: |
-          xvfb-run poetry run make -C doc html SPHINXOPTS="-W --keep-going -v $SPHINXOPT_NITPICKY"
+          poetry run make -C doc html SPHINXOPTS="-W --keep-going -v $SPHINXOPT_NITPICKY"
         env:
           PYMAPDL_IP: "127.0.0.1"
           PYMAPDL_PORT: "50557"
@@ -505,7 +510,6 @@ jobs:
           SPHINXOPT_NITPICKY: ${{ matrix.build_type == 'quick' && ' ' || '-n' }}
           PYACP_DOC_SKIP_GALLERY: ${{ matrix.build_type == 'quick' && 'true' || 'false' }}
           PYACP_DOC_SKIP_API: ${{ matrix.build_type == 'quick' && 'true' || 'false' }}
-          LIBGL_ALWAYS_SOFTWARE: 1
 
       - name: Stop and clean up MAPDL and DPF servers
         run: |
@@ -534,10 +538,8 @@ jobs:
         if: ${{ matrix.build_type == 'full' }}
 
       - name: Build PDF Documentation
-        run: xvfb-run poetry run make -C doc pdf
+        run: poetry run make -C doc pdf
         if: ${{ matrix.build_type == 'full' }}
-        env:
-          LIBGL_ALWAYS_SOFTWARE: 1
 
       - name: Upload PDF Documentation
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Use the PyVista - provided action to configure a headless display, instead of manually installing / using `xvfb` and the `LIBGL_ALWAYS_SOFTWARE` environment variable.