### PR TITLE
Bump the version to 0.2.1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ansys-acp-core"
-version = "0.1.dev0"
+version = "0.2.1.dev0"
 
 description = "Python library for ACP - Ansys Composite PrepPost"
 readme = "README.rst"


### PR DESCRIPTION
Since the lowest possible version number for the next release is `0.2.1`, bump
the development version to `0.2.1.dev0`.