### PR TITLE
Add a `connect_local` launch mode

### DIFF
--- a/doc/source/api/server.rst
+++ b/doc/source/api/server.rst
@@ -8,6 +8,7 @@ Server management
 
     ACPInstance
     ConnectLaunchConfig
+    ConnectLocalLaunchConfig
     DirectLaunchConfig
     DockerComposeLaunchConfig
     launch_acp

--- a/doc/source/user_guide/howto/launch_configuration.rst
+++ b/doc/source/user_guide/howto/launch_configuration.rst
@@ -88,6 +88,7 @@ This parameter expects a configuration object matching the selected ``launch_mod
 - :class:`.DirectLaunchConfig` for the ``direct`` launch mode.
 - :class:`.DockerComposeLaunchConfig` for the ``docker_compose`` launch mode.
 - :class:`.ConnectLaunchConfig` for the ``connect`` launch mode.
+- :class:`.ConnectLocalLaunchConfig` for the ``connect_local`` launch mode.
 
 .. testcode::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ all = [
 "ACP.direct" = "ansys.acp.core._server.direct:DirectLauncher"
 "ACP.docker_compose" = "ansys.acp.core._server.docker_compose:DockerComposeLauncher"
 "ACP.connect" = "ansys.acp.core._server.connect:ConnectLauncher"
+"ACP.connect_local" = "ansys.acp.core._server.connect:ConnectLocalLauncher"
 "ACP.__fallback__" = "ansys.acp.core._server.direct:DirectLauncher"
 
 [[tool.poetry.source]]

--- a/src/ansys/acp/core/__init__.py
+++ b/src/ansys/acp/core/__init__.py
@@ -40,6 +40,7 @@ from ._recursive_copy import LinkedObjectHandling, recursive_copy
 from ._server import (
     ACPInstance,
     ConnectLaunchConfig,
+    ConnectLocalLaunchConfig,
     DirectLaunchConfig,
     DockerComposeLaunchConfig,
     LaunchMode,
@@ -173,6 +174,7 @@ __all__ = [
     "CADComponent",
     "CADGeometry",
     "ConnectLaunchConfig",
+    "ConnectLocalLaunchConfig",
     "CoordinateTransformation",
     "CutOffGeometry",
     "CutOffGeometryOrientationType",

--- a/src/ansys/acp/core/_server/__init__.py
+++ b/src/ansys/acp/core/_server/__init__.py
@@ -22,7 +22,7 @@
 
 from .acp_instance import ACPInstance
 from .common import LaunchMode
-from .connect import ConnectLaunchConfig
+from .connect import ConnectLaunchConfig, ConnectLocalLaunchConfig
 from .direct import DirectLaunchConfig
 from .docker_compose import DockerComposeLaunchConfig
 from .launch import launch_acp
@@ -30,6 +30,7 @@ from .launch import launch_acp
 __all__ = [
     "ACPInstance",
     "ConnectLaunchConfig",
+    "ConnectLocalLaunchConfig",
     "DirectLaunchConfig",
     "DockerComposeLaunchConfig",
     "launch_acp",

--- a/src/ansys/acp/core/_server/acp_instance.py
+++ b/src/ansys/acp/core/_server/acp_instance.py
@@ -307,11 +307,13 @@ class ACPInstance(Generic[ServerT]):
         Note that the models are listed in arbitrary order.
         """
         from .._tree_objects import Model
+        from .._tree_objects.base import ServerWrapper
 
         model_stub = model_pb2_grpc.ObjectServiceStub(self._channel)
+        server_wrapper = ServerWrapper.from_acp_instance(self)
         return tuple(
             [
-                Model._from_object_info(model_info, self._channel)
+                Model._from_object_info(model_info, server_wrapper)
                 for model_info in model_stub.List(
                     ListRequest(collection_path=CollectionPath(value=Model._COLLECTION_LABEL))
                 ).objects

--- a/src/ansys/acp/core/_server/common.py
+++ b/src/ansys/acp/core/_server/common.py
@@ -42,6 +42,7 @@ class LaunchMode(StrEnum):
     DIRECT = "direct"
     DOCKER_COMPOSE = "docker_compose"
     CONNECT = "connect"
+    CONNECT_LOCAL = "connect_local"
 
 
 class ServerProtocol(Protocol):

--- a/src/ansys/acp/core/_server/connect.py
+++ b/src/ansys/acp/core/_server/connect.py
@@ -84,7 +84,6 @@ class ConnectLocalLaunchConfig:
     """Configuration options for attaching to an existing ACP server without filetransfer."""
 
     url_acp: str = dataclasses.field(
-        default="localhost:9090",
         metadata={METADATA_KEY_DOC: "URL to connect to for the main ACP server."},
     )
 

--- a/src/ansys/acp/core/_server/launch.py
+++ b/src/ansys/acp/core/_server/launch.py
@@ -38,7 +38,7 @@ from .acp_instance import (
     RemoteFileTransferStrategy,
 )
 from .common import ControllableServerProtocol, LaunchMode, ServerKey
-from .connect import ConnectLaunchConfig
+from .connect import ConnectLaunchConfig, ConnectLocalLaunchConfig
 from .direct import DirectLaunchConfig
 from .docker_compose import DockerComposeLaunchConfig
 
@@ -46,7 +46,13 @@ __all__ = ["launch_acp"]
 
 
 def launch_acp(
-    config: DirectLaunchConfig | DockerComposeLaunchConfig | ConnectLaunchConfig | None = None,
+    config: (
+        DirectLaunchConfig
+        | DockerComposeLaunchConfig
+        | ConnectLaunchConfig
+        | ConnectLocalLaunchConfig
+        | None
+    ) = None,
     launch_mode: LaunchMode | None = None,
     timeout: float | None = 30.0,
     auto_transfer_files: bool = True,
@@ -96,7 +102,11 @@ def launch_acp(
         product_name="ACP", config=config, launch_mode=launch_mode_evaluated
     )
     # The fallback launch mode for ACP is the direct launch mode.
-    if launch_mode_evaluated in (LaunchMode.DIRECT, FALLBACK_LAUNCH_MODE_NAME):
+    if launch_mode_evaluated in (
+        LaunchMode.DIRECT,
+        LaunchMode.CONNECT_LOCAL,
+        FALLBACK_LAUNCH_MODE_NAME,
+    ):
         filetransfer_strategy: FileTransferStrategy = LocalFileTransferStrategy(os.getcwd())
         is_remote = False
     elif launch_mode_evaluated in (LaunchMode.DOCKER_COMPOSE, LaunchMode.CONNECT):


### PR DESCRIPTION
- Adds a new launch mode `connect_local`, which connects to an existing ACP server, but without using the file transfer service.
- Fixes `ACPInstance.models`: The `Model._from_object_info` was incorrectly called with a bare gRPC channel, instead of a `ServerWrapper` instance. This bug wasn't caught because it only affects the case when connecting to an existing server which already has models loaded. Otherwise, the instance caching mechanism means that all models are instantiated when initially loaded via `import_model`, which works correctly.