### PR TITLE
Explicitly listen only on localhost / 127.0.0.1 when launching the server

### DIFF
--- a/docker-compose/docker-compose-benchmark.yaml
+++ b/docker-compose/docker-compose-benchmark.yaml
@@ -14,7 +14,7 @@ services:
     environment:
       - ANSYSLMD_LICENSE_FILE=${ANSYSLMD_LICENSE_FILE}
     ports:
-      - "${PORT_ACP:-50555}:50051"
+      - "127.0.0.1:${PORT_ACP:-50555}:50051"
     working_dir: /home/container/workdir
     volumes:
       - "acp_data:/home/container/workdir/"
@@ -25,7 +25,7 @@ services:
     restart: unless-stopped
     image: ${IMAGE_NAME_FILETRANSFER:-ghcr.io/ansys/tools-filetransfer:latest}
     ports:
-      - "${PORT_FILETRANSFER:-50556}:50000"
+      - "127.0.0.1:${PORT_FILETRANSFER:-50556}:50000"
     working_dir: /home/container/workdir
     volumes:
       - "acp_data:/home/container/workdir/"

--- a/docker-compose/docker-compose-extras.yaml
+++ b/docker-compose/docker-compose-extras.yaml
@@ -8,7 +8,7 @@ services:
     command: ${MAPDL_CMD:--smp -np 1}
     shm_size: '4gb'
     ports:
-    - "${PYMAPDL_PORT:-50557}:50052"
+    - "127.0.0.1:${PYMAPDL_PORT:-50557}:50052"
     environment:
       - ANSYSLMD_LICENSE_FILE=${ANSYSLMD_LICENSE_FILE}
       - ANSYS_LOCK="OFF"
@@ -16,7 +16,7 @@ services:
     restart: unless-stopped
     image: ${IMAGE_NAME_DPF_COMPOSITES:-ghcr.io/ansys/pydpf-composites:latest}
     ports:
-    - "${PYDPF_COMPOSITES_DOCKER_CONTAINER_PORT:-50558}:50052"
+    - "127.0.0.1:${PYDPF_COMPOSITES_DOCKER_CONTAINER_PORT:-50558}:50052"
     environment:
       - ANSYSLMD_LICENSE_FILE=${ANSYSLMD_LICENSE_FILE}
       - ANSYS_DPF_ACCEPT_LA=${ANSYS_DPF_ACCEPT_LA}

--- a/src/ansys/acp/core/_server/direct.py
+++ b/src/ansys/acp/core/_server/direct.py
@@ -98,7 +98,7 @@ class DirectLauncher(LauncherProtocol[DirectLaunchConfig]):
         self._process = subprocess.Popen(  # nosec B603: documented in 'security_considerations.rst'
             [
                 self._config.binary_path,
-                f"--server-address=0.0.0.0:{port}",
+                f"--server-address=localhost:{port}",
             ],
             stdout=self._stdout,
             stderr=self._stderr,

--- a/src/ansys/acp/core/_server/docker-compose.yaml
+++ b/src/ansys/acp/core/_server/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     environment:
       - ANSYSLMD_LICENSE_FILE=${ANSYSLMD_LICENSE_FILE}
     ports:
-      - "${PORT_ACP:-50555}:50051"
+      - "127.0.0.1:${PORT_ACP:-50555}:50051"
     working_dir: /home/container/workdir
     volumes:
       - "acp_data:/home/container/workdir/"
@@ -14,7 +14,7 @@ services:
     restart: unless-stopped
     image: ${IMAGE_NAME_FILETRANSFER:-ghcr.io/ansys/tools-filetransfer:latest}
     ports:
-      - "${PORT_FILETRANSFER:-50556}:50000"
+      - "127.0.0.1:${PORT_FILETRANSFER:-50556}:50000"
     working_dir: /home/container/workdir
     volumes:
       - "acp_data:/home/container/workdir/"


### PR DESCRIPTION
- In `direct` launch mode, listen only on `localhost`
- In `docker_compose` launch mode, limit connections to coming from `127.0.0.1` by limiting the source IP in the `ports` mapping