### PR TITLE
Remove the puck material type ignored

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -237,6 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", '3.13', '3.14']
         server-version: ["latest"]

--- a/doc/source/user_guide/compatibility.rst
+++ b/doc/source/user_guide/compatibility.rst
@@ -13,12 +13,12 @@ almost all features of ACP available through PyACP.
 
 .. important::
 
-  For releases 2024 R2, 2025 R1, and 2025 R2, it is strongly recommended that you use 
-  Service Pack versions 2024 R2 SP5, 2025 R1 SP4, and 2025 R2 SP3 or newer, respectively. 
-  In these versions, the gRPC server now restricts connections to only the user who launched 
+  For releases 2024 R2, 2025 R1, and 2025 R2, it is strongly recommended that you use
+  Service Pack versions 2024 R2 SP5, 2025 R1 SP4, and 2025 R2 SP3 or newer, respectively.
+  In these versions, the gRPC server now restricts connections to only the user who launched
   the gRPC server on the local machine (127.0.0.1) by default.
 
-  Older versions of each release only support the INSECURE transport mode, which is not 
+  Older versions of each release only support the INSECURE transport mode, which is not
   recommended because there is no encryption or authentication.
 
 Added in 2025R2
@@ -89,6 +89,15 @@ Upgrading PyACP
 ---------------
 
 The following section describes how to upgrade to newer versions of PyACP.
+
+Upgrading to version `0.4.0`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Breaking changes:
+
+- The ``PuckMaterialType.IGNORED`` option was removed. Disable the Puck constants
+  by setting the ``Material.puck_constants`` attribute to ``None`` for the
+  material(s) that used this option.
 
 Upgrading from the beta version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/user_guide/compatibility.rst
+++ b/doc/source/user_guide/compatibility.rst
@@ -97,7 +97,7 @@ Breaking changes:
 
 - The ``PuckMaterialType.IGNORED`` option was removed. Disable the Puck constants
   by setting the ``Material.puck_constants`` attribute to ``None`` for the
-  material(s) that used this option.
+  materials which used this option.
 
 Upgrading from the beta version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docker-compose/docker-compose-base.yaml
+++ b/docker-compose/docker-compose-base.yaml
@@ -1,1 +1,0 @@
-../src/ansys/acp/core/_server/docker-compose-base.yaml

--- a/dockerfiles/ConnectionTest.Dockerfile
+++ b/dockerfiles/ConnectionTest.Dockerfile
@@ -34,6 +34,10 @@ tc filter add dev eth0 parent ffff: protocol ip u32 match u32 0 0 flowid 1:1 act
 
 tc qdisc add dev eth0 root netem delay \$DELAY rate \$RATE
 tc qdisc add dev ifb0 root netem delay \$DELAY rate \$RATE
+
+# Ensure the working directory is writable by the container user
+chmod -R 777 /home/container/workdir
+
 sudo -u container --preserve-env /usr/ansys_inc/acp/acp_grpcserver "\$@"
 EOF
 #escape=\

--- a/src/ansys/acp/core/_tree_objects/material/property_sets/puck_constants.py
+++ b/src/ansys/acp/core/_tree_objects/material/property_sets/puck_constants.py
@@ -45,10 +45,17 @@ __all__ = ["ConstantPuckConstants", "VariablePuckConstants", "PuckMaterialType"]
 class PuckMaterialType(str, Enum):
     """Possible Puck material types."""
 
-    IGNORED = "ignored"
     CARBON = "carbon"
     GLASS = "glass"
     MATERIAL_SPECIFIC = "material-specific"
+
+    @classmethod
+    def _missing_(cls, value: object) -> None:
+        if isinstance(value, str) and value.lower() == "ignored":
+            # Raise custom error for the removed "ignored" material type
+            raise ValueError(
+                "The 'ignored' Puck material type is no longer supported. Disable the Puck constants instead."
+            )
 
 
 class _PuckConstantsMixin:
@@ -72,7 +79,7 @@ class ConstantPuckConstants(_PuckConstantsMixin, _ConstantPropertySet):
         s: float = 0.5,
         M: float = 0.5,
         interface_weakening_factor: float = 0.8,
-        mat_type: str = PuckMaterialType.IGNORED,
+        mat_type: str = PuckMaterialType.CARBON,
         _parent_object: TreeObject | None = None,
         _attribute_path: str | None = None,
     ):
@@ -87,7 +94,11 @@ class ConstantPuckConstants(_PuckConstantsMixin, _ConstantPropertySet):
 
         self.mat_type = PuckMaterialType(mat_type)
 
-        if mat_type in (PuckMaterialType.IGNORED, PuckMaterialType.MATERIAL_SPECIFIC):
+        if mat_type == "ignored":
+            raise ValueError(
+                "The 'ignored' Puck material type is no longer supported. Remove the Puck constants instead."
+            )
+        elif mat_type == PuckMaterialType.MATERIAL_SPECIFIC:
             self.p_21_pos = val_or_default(p_21_pos, 0.325)
             self.p_21_neg = val_or_default(p_21_neg, 0.275)
             self.p_22_pos = val_or_default(p_22_pos, 0.225)

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -51,7 +51,13 @@ def pytest_ignore_collect(collection_path, config):
     # used for manipulating network speeds is not available on Docker for
     # Windows / Mac.
     if sys.platform != "linux":
-        return True
+        if not config.getoption(VALIDATE_BENCHMARKS_ONLY_OPTION_KEY):
+            print(
+                "Skipping benchmarks since they can only be run on Linux. "
+                "Use the '--validate-benchmarks-only' option to validate the "
+                "benchmarks on any platform."
+            )
+            return True
     # The benchmarks make use of the 'ConnectionTest.Dockerfile' and
     # 'docker-compose-benchmark.yaml', so can only be used with the
     # docker-compose launcher.
@@ -80,6 +86,8 @@ def launcher_configuration(request):
                 "build",
                 "--tag",
                 BENCHMARK_IMAGE_NAME,
+                "--build-arg",
+                f"BASE_IMAGE={base_image_name}",
                 "-f",
                 benchmark_dockerfile,
                 dockerfiles_dir,


### PR DESCRIPTION
Remove the `PuckMaterialType.IGNORED` option, since it has also been removed in the backend.

Note that this is a breaking change, so the next version will need to be 0.4.0.

Other changes: 
- Fix the benchmark tests in CI by ensuring that `/home/container/workdir` is writable by all users.
- Fix the base image used in the benchmark tests (previously, it would always use `latest`).
- Set `fail-fast` to `false` in the CI tests, to gather better data on sporadic failures.