### PR TITLE
Dependabot: group github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*" # Update all packages together
     cooldown:
       include:
         - '*'


### PR DESCRIPTION
Use grouped updates for the `github-actions` dependencies, to minimize the number of PRs.