### PR TITLE
Add actions security CI check

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -483,9 +483,9 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     environment: release
-    permissions: # INFO: Trusted publishers require these permissions
-      id-token: write
-      contents: write
+    permissions:
+      id-token: write # trusted publishers require these permissions
+      contents: write # trusted publishers require these permissions
     steps:
       - name: "Download the library artifacts from build-library step"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -513,7 +513,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     permissions:
-      contents: write
+      contents: write # needs to write to the gh-pages branch
     steps:
       - name: Deploy the latest documentation
         uses: ansys/actions/doc-deploy-dev@v10.3.2
@@ -529,7 +529,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release]
     permissions:
-      contents: write
+      contents: write # needs to write to the gh-pages branch
     steps:
       - name: Deploy the stable documentation
         uses: ansys/actions/doc-deploy-stable@v10.3.2

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -310,7 +310,7 @@ jobs:
         working-directory: tests/unittests
         run: >
           uv run --no-sync ansys-launcher configure ACP docker_compose
-          --image_name_acp=${{ env.DOCKER_IMAGE_NAME }}
+          --image_name_acp=${DOCKER_IMAGE_NAME}
           --image_name_filetransfer=ghcr.io/ansys/tools-filetransfer:latest
           --license_server=1055@$LICENSE_SERVER
           --transport_mode=mtls
@@ -322,12 +322,11 @@ jobs:
 
       - name: Run doctest
         run: |
-          docker pull $IMAGE_NAME
+          docker pull ${DOCKER_IMAGE_NAME}
           docker pull ghcr.io/ansys/tools-filetransfer:latest
           uv run --no-sync make -C doc doctest
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
-          IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
           PYACP_DOC_SKIP_GALLERY: "true"
           PYACP_DOC_SKIP_API: "true"
           ANSYS_GRPC_CERTIFICATES: ${{ github.workspace }}/tests/insecure_certs
@@ -367,7 +366,7 @@ jobs:
       - name: Configure Local Product Launcher for ACP
         run: >
           uv run --no-sync ansys-launcher configure ACP docker_compose
-          --image_name_acp=${{ env.DOCKER_IMAGE_NAME }}
+          --image_name_acp=${DOCKER_IMAGE_NAME}
           --image_name_filetransfer=ghcr.io/ansys/tools-filetransfer:latest
           --license_server=1055@$LICENSE_SERVER
           --transport_mode=mtls
@@ -396,10 +395,8 @@ jobs:
 
       - name: Pull ACP and filetransfer images
         run: |
-          docker pull $IMAGE_NAME
+          docker pull ${DOCKER_IMAGE_NAME}
           docker pull ghcr.io/ansys/tools-filetransfer:latest
-        env:
-          IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
         if: ${{ matrix.build_type == 'full' }}
 
       - name: Build HTML

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login in Github Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -155,7 +155,7 @@ jobs:
         run: uv sync --group test --no-dev
 
       - name: Login in Github Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -209,7 +209,7 @@ jobs:
         run: uv sync --group test --extra graphics --no-dev
 
       - name: Login in Github Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -268,7 +268,7 @@ jobs:
         run: uv sync --all-groups --all-extras
 
       - name: Login in Github Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -350,7 +350,7 @@ jobs:
         if: ${{ matrix.build_type == 'full' }}
 
       - name: Login in Github Container registry (PYANSYS_CI_BOT)
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -84,6 +84,17 @@ jobs:
           dev-mode: ${{ github.ref != 'refs/heads/main' }}
           extra-targets: "graphics"
 
+  check-actions-security:
+    name: "Check actions security"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ansys/actions/check-actions-security@v10.3
+        with:
+          generate-summary: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          auditing-level: 'high'
+          trust-ansys-actions: true
+
   testing-direct-launch:
     name: Testing with direct launch mode
     runs-on: ubuntu-latest
@@ -418,7 +429,17 @@ jobs:
   build:
     name: Build library
     runs-on: ubuntu-latest
-    needs: [code-style, testing, testing-minimum-deps, testing-direct-launch, doc-style, docs, build-wheelhouse, doctest] # TODO: add check-vulnerabilities once we know it works on main
+    needs:
+      - build-wheelhouse
+      - check-actions-security
+      - check-vulnerabilities
+      - code-style
+      - doc-style
+      - docs
+      - doctest
+      - testing
+      - testing-direct-launch
+      - testing-minimum-deps
     timeout-minutes: 30
     steps:
       - name: Build library source and wheel artifacts

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
@@ -101,7 +101,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login in Github Container registry
         uses: docker/login-action@v4
         with:
@@ -137,7 +137,7 @@ jobs:
         python-version: ["3.11", "3.12", '3.13', '3.14']
         server-version: ["latest"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
@@ -198,7 +198,7 @@ jobs:
             server-version: "2026R1"
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
@@ -257,7 +257,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v7
@@ -317,7 +317,7 @@ jobs:
         build_type: ["quick", "full"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -254,10 +254,15 @@ jobs:
       - name: Benchmarks
         working-directory: tests/benchmarks
         run: |
-          uv run --no-sync pytest -v --license-server=1055@$LICENSE_SERVER --no-server-log-files --docker-image=$IMAGE_NAME --build-benchmark-image --benchmark-json benchmark_output.json --benchmark-group-by=fullname ${{ (matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.server-version == 'latest') && ' ' || '--validate-benchmarks-only' }}
+          benchmark_mode_args=""
+          if [ "$RUN_FULL_BENCHMARKS" != "true" ]; then
+            benchmark_mode_args="--validate-benchmarks-only"
+          fi
+          uv run --no-sync pytest -v --license-server=1055@$LICENSE_SERVER --no-server-log-files --docker-image=$IMAGE_NAME --build-benchmark-image --benchmark-json benchmark_output.json --benchmark-group-by=fullname $benchmark_mode_args
         env:
           LICENSE_SERVER: ${{ secrets.LICENSE_SERVER }}
           IMAGE_NAME: ghcr.io/ansys/acp:${{ matrix.server-version }}
+          RUN_FULL_BENCHMARKS: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.server-version == 'latest' }}
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -33,12 +33,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          enable-cache: false
 
 
       - name: Run pre-commit
@@ -103,6 +105,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Login in Github Container registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -139,12 +143,14 @@ jobs:
         server-version: ["latest"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          enable-cache: false
 
       - name: Install library, with only the 'main' group
         run: uv sync --no-dev --no-group test
@@ -201,12 +207,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          enable-cache: false
 
       - name: Install library, with test group and graphics extra
         run: uv sync --group test --extra graphics --no-dev
@@ -261,12 +269,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          enable-cache: false
 
       - name: Install library, with test,dev groups
         run: uv sync --all-groups --all-extras
@@ -322,12 +332,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          enable-cache: false
 
       - name: Install OS packages
         run: |

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -104,6 +104,8 @@ jobs:
     name: Testing with direct launch mode
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      packages: read # needed for pulling the Docker image
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -143,6 +145,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", '3.13', '3.14']
         server-version: ["latest"]
+    permissions:
+      packages: read # needed for pulling the Docker image
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -192,6 +196,8 @@ jobs:
     name: Testing
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      packages: read # needed for pulling the Docker image
     strategy:
       fail-fast: false
       matrix:
@@ -268,6 +274,8 @@ jobs:
     name: Test documentation snippets
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      packages: read # needed for pulling the Docker image
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -328,6 +336,8 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      packages: read # needed for pulling the Docker image
     strategy:
       matrix:
         build_type: ["quick", "full"]
@@ -472,10 +482,8 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [build]
     runs-on: ubuntu-latest
-    # INFO: Specifying a GitHub environment is optional but encouraged
     environment: release
-    # INFO: Trusted publishers require these permissions
-    permissions:
+    permissions: # INFO: Trusted publishers require these permissions
       id-token: write
       contents: write
     steps:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -13,6 +13,8 @@ on:
       docker_image_suffix:
         description: "Suffix of the 'acp' docker image used for testing. For example, ':latest', or '@sha256:<hash>' (without quotes)."
         required: false
+permissions:
+  contents: read
 
 env:
   MAIN_PYTHON_VERSION: "3.14"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -244,7 +244,7 @@ jobs:
           IMAGE_NAME: ghcr.io/ansys/acp:${{ matrix.server-version }}
 
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: 'PyACP benchmarks'
           tool: 'pytest'
@@ -398,7 +398,7 @@ jobs:
           docker compose -f ./docker-compose/docker-compose-extras.yaml down -v
 
       - name: Upload HTML Documentation
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: documentation-html
           path: doc/build/html
@@ -424,7 +424,7 @@ jobs:
         if: ${{ matrix.build_type == 'full' }}
 
       - name: Upload PDF Documentation
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: documentation-pdf
           path: doc/build/latex/ansys-acp-core.pdf

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -502,6 +502,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      contents: write
     steps:
       - name: Deploy the latest documentation
         uses: ansys/actions/doc-deploy-dev@v10.3.2
@@ -516,6 +518,8 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs: [release]
+    permissions:
+      contents: write
     steps:
       - name: Deploy the stable documentation
         uses: ansys/actions/doc-deploy-stable@v10.3.2

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -35,9 +35,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 
       - name: Run pre-commit
@@ -140,9 +141,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install library, with only the 'main' group
         run: uv sync --no-dev --no-group test
@@ -201,9 +203,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install library, with test group and graphics extra
         run: uv sync --group test --extra graphics --no-dev
@@ -260,9 +263,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install library, with test,dev groups
         run: uv sync --all-groups --all-extras
@@ -320,9 +324,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Install OS packages
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,10 +18,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -39,7 +39,7 @@ jobs:
           pip install -r requirements-test.txt
 
       - name: Login in Github Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: pyansys-ci-bot

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+concurrency:
+  group: nightly-test
+  cancel-in-progress: true
 permissions:
   contents: read
   packages: read # needed for pulling the Docker image

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
+  packages: read # needed for pulling the Docker image
 env:
   UV_FROZEN: "true"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
-
+permissions:
+  contents: read
 env:
   UV_FROZEN: "true"
 

--- a/.github/workflows/package_cleanup.yml
+++ b/.github/workflows/package_cleanup.yml
@@ -9,7 +9,7 @@ jobs:
     name: "Delete untagged package versions"
     runs-on: ubuntu-latest
     permissions:
-      packages: write
+      packages: write # needs to be able to delete packages
     steps:
       - name: "Delete untagged package versions"
         uses: ansys/actions/hk-package-clean-untagged@v10.3.2

--- a/.github/workflows/package_cleanup.yml
+++ b/.github/workflows/package_cleanup.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 2 * * *"
 permissions:
   contents: read
+concurrency:
+  group: package-cleanup
+  cancel-in-progress: true
 
 jobs:
   cleanup:

--- a/.github/workflows/package_cleanup.yml
+++ b/.github/workflows/package_cleanup.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   schedule: # UTC at 0200
     - cron: "0 2 * * *"
+permissions:
+  contents: read
 
 jobs:
   cleanup:

--- a/.github/workflows/package_cleanup.yml
+++ b/.github/workflows/package_cleanup.yml
@@ -4,14 +4,12 @@ on:
   schedule: # UTC at 0200
     - cron: "0 2 * * *"
 
-permissions:
-  contents: write
-  packages: write
-
 jobs:
   cleanup:
     name: "Delete untagged package versions"
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: "Delete untagged package versions"
         uses: ansys/actions/hk-package-clean-untagged@v10.3.2


### PR DESCRIPTION
Add the [`ansys/actions/check-actions-security` ](https://actions.docs.ansys.com/version/stable/vulnerability-actions/index.html#check-actions-security-action) action to the CI, which runs the [zizmor](https://github.com/zizmorcore/zizmor)
static analysis tool over the CI definition.

Fix the issues flagged by zizmor:
- pin all action dependencies, except `ansys/actions` (configured as a trusted source)
- more granular permissions in the workflows / jobs
- avoid template expressions in a shell context (https://docs.zizmor.sh/audits/#template-injection)
- disable uv cache to avoid cache poisoning (https://docs.zizmor.sh/audits/#cache-poisoning)
- disable concurrent execution of `nightly.yml` and `package_cleanup.yml` (https://docs.zizmor.sh/audits/#concurrency-limits)

Resolves #905