### PR TITLE
Improve enum listings in the API documentation.

### DIFF
--- a/doc/source/api/enum_types.rst
+++ b/doc/source/api/enum_types.rst
@@ -32,7 +32,6 @@ Enumeration data types
     ImportedPlyOffsetType
     ImportedPlyThicknessType
     IntersectionType
-    LaunchMode
     LayupMappingRosetteSelectionMethod
     LinkedObjectHandling
     LookUpTable3DInterpolationAlgorithm

--- a/doc/source/api/material_property_sets.rst
+++ b/doc/source/api/material_property_sets.rst
@@ -17,6 +17,14 @@ Material property sets
     ConstantWovenCharacterization
     ConstantWovenStressLimits
     FieldVariable
+
+    :template: autosummary/no_methods_doc/class.rst.jinja2
+
+    InterpolationOptions
+    PuckMaterialType
+
+    :template: autosummary/class.rst
+
     VariableDensity
     VariableEngineeringConstants
     VariableFabricFiberAngle
@@ -27,10 +35,3 @@ Material property sets
     VariableTsaiWuConstants
     VariableWovenCharacterization
     VariableWovenStressLimits
-
-.. autosummary::
-    :toctree: _autosummary
-    :template: autosummary/no_methods_doc/class.rst.jinja2
-
-    InterpolationOptions
-    PuckMaterialType

--- a/doc/source/api/server.rst
+++ b/doc/source/api/server.rst
@@ -12,3 +12,7 @@ Server management
     DirectLaunchConfig
     DockerComposeLaunchConfig
     launch_acp
+
+    :template: autosummary/no_methods_doc/class.rst.jinja2
+
+    LaunchMode


### PR DESCRIPTION
- Move the enum types in `material_property_sets.rst` into the main `autosummary` directive by switching to the `no_methods_doc` template in-line. This makes the full list of classes render as one, instead of with a break before the enum types.
- Move `LaunchMode` back into `server.rst`. This was previously moved to `enum_types.rst` since I wasn't aware of the inline template option.