### PR TITLE
Bump API package and adapt to changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "numpy>=1.22",
     "grpcio-health-checking>=1.43",
     "packaging>=15.0",
-    "ansys-api-acp==0.3.1",
+    "ansys-api-acp==0.4.0.dev0",
     "ansys-tools-common>=0.4.0",
     "ansys-tools-filetransfer>=0.2.1",
     "networkx>=3.0.0",
@@ -157,3 +157,6 @@ branch = true
 
 [tool.coverage.report]
 exclude_also = ["if (typing\\.)?TYPE_CHECKING:"]
+
+[tool.uv.sources]
+ansys-api-acp = { git = "https://github.com/ansys/ansys-api-acp.git", branch = "feat/update_protos" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "numpy>=1.22",
     "grpcio-health-checking>=1.43",
     "packaging>=15.0",
-    "ansys-api-acp==0.4.0.dev0",
+    "ansys-api-acp==0.4.0",
     "ansys-tools-common>=0.4.0",
     "ansys-tools-filetransfer>=0.2.1",
     "networkx>=3.0.0",
@@ -157,6 +157,3 @@ branch = true
 
 [tool.coverage.report]
 exclude_also = ["if (typing\\.)?TYPE_CHECKING:"]
-
-[tool.uv.sources]
-ansys-api-acp = { git = "https://github.com/ansys/ansys-api-acp.git", branch = "feat/update_protos" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.22",
-    "grpcio-health-checking>=1.43",
+    "grpcio-health-checking>=1.71",
     "packaging>=15.0",
     "ansys-api-acp==0.4.0",
     "ansys-tools-common>=0.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "numpy>=1.22",
     "grpcio-health-checking>=1.71",
     "packaging>=15.0",
-    "ansys-api-acp==0.4.0",
+    "ansys-api-acp==0.4.1",
     "ansys-tools-common>=0.4.0",
     "ansys-tools-filetransfer>=0.2.1",
     "networkx>=3.0.0",

--- a/src/ansys/acp/core/_tree_objects/_grpc_helpers/property_helper.py
+++ b/src/ansys/acp/core/_tree_objects/_grpc_helpers/property_helper.py
@@ -32,6 +32,7 @@ from collections.abc import Callable
 from functools import reduce
 import sys
 from typing import TYPE_CHECKING, Any, TypeVar
+import warnings
 
 from google.protobuf.message import Message
 
@@ -175,6 +176,7 @@ def grpc_data_getter(
     check_optional: bool = False,
     getter_func: Callable[[Message, str, bool], _PROTOBUF_T] = _get_data_attribute,
     supported_since: str | None = None,
+    deprecated_msg: str | None = None,
 ) -> Callable[[Readable], _GET_T]:
     """Create a getter method which obtains the server object via the gRPC Get endpoint.
 
@@ -198,6 +200,12 @@ def grpc_data_getter(
         ),
     )
     def inner(self: Readable) -> Any:
+        if deprecated_msg is not None:
+            warnings.warn(
+                deprecated_msg,
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._get_if_stored()
         pb_attribute = getter_func(self._pb_object, name, check_optional)
         if check_optional and pb_attribute is None:
@@ -245,6 +253,7 @@ def grpc_data_setter(
     to_protobuf: _TO_PROTOBUF_T[_SET_T],
     setter_func: Callable[[ObjectInfo, str, _PROTOBUF_T], None] = _set_data_attribute,
     supported_since: str | None = None,
+    deprecated_msg: str | None = None,
 ) -> Callable[[Editable, _SET_T], None]:
     """Create a setter method which updates the server object via the gRPC Put endpoint."""
 
@@ -257,6 +266,12 @@ def grpc_data_setter(
         ),
     )
     def inner(self: Editable, value: _SET_T) -> None:
+        if deprecated_msg is not None:
+            warnings.warn(
+                deprecated_msg,
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._get_if_stored()
         current_value = _get_data_attribute(self._pb_object, name, check_optional=True)
         value_pb = to_protobuf(value)
@@ -290,6 +305,7 @@ def grpc_data_property(
     getter_func: Callable[[Message, str, bool], _PROTOBUF_T] = _get_data_attribute,
     readable_since: str | None = None,
     writable_since: str | None = None,
+    deprecated_msg: str | None = None,
 ) -> ReadWriteProperty[_GET_T, _SET_T]:
     """Define a property which is synchronized with the backend via gRPC.
 
@@ -340,6 +356,7 @@ def grpc_data_property(
                 check_optional=check_optional,
                 getter_func=getter_func,
                 supported_since=readable_since,
+                deprecated_msg=deprecated_msg,
             )
         ).setter(
             grpc_data_setter(
@@ -347,6 +364,7 @@ def grpc_data_property(
                 to_protobuf=to_protobuf,
                 setter_func=setter_func,
                 supported_since=writable_since,
+                deprecated_msg=deprecated_msg,
             )
         ),
         doc=doc,

--- a/src/ansys/acp/core/_tree_objects/model.py
+++ b/src/ansys/acp/core/_tree_objects/model.py
@@ -42,6 +42,7 @@ from ansys.api.acp.v0 import (
     fabric_pb2_grpc,
     field_definition_pb2_grpc,
     geometrical_selection_rule_pb2_grpc,
+    hdf5_composite_cae_import_pb2,
     imported_modeling_group_pb2_grpc,
     imported_solid_model_pb2_grpc,
     lookup_table_1d_pb2_grpc,
@@ -169,13 +170,13 @@ IgnorableEntity, ignorable_entity_to_pb, _ = wrap_to_string_enum(
 )
 HDF5CompositeCAEImportMode, hdf5_composite_cae_import_mode_to_pb, _ = wrap_to_string_enum(
     "HDF5CompositeCAEImportMode",
-    model_pb2.ImportMode,
+    hdf5_composite_cae_import_pb2.ImportMode,
     module=__name__,
     doc="Options for the import mode of the HDF5 Composite CAE file.",
 )
 HDF5CompositeCAEProjectionMode, hdf5_composite_cae_projection_mode_to_pb, _ = wrap_to_string_enum(
     "HDF5CompositeCAEProjectionMode",
-    model_pb2.ProjectionMode,
+    hdf5_composite_cae_import_pb2.ProjectionMode,
     module=__name__,
     doc="Options for the projection mode of the HDF5 Composite CAE file.",
 )
@@ -416,7 +417,7 @@ class Model(TreeObject):
         with wrap_grpc_errors():
             self._get_stub().Update(
                 model_pb2.UpdateRequest(
-                    resource_path=self._resource_path, relations_only=relations_only
+                    resource_path=[self._resource_path], relations_only=relations_only
                 )
             )
 
@@ -563,10 +564,10 @@ class Model(TreeObject):
         """
         if projection_mode == HDF5CompositeCAEProjectionMode.SHELL:
             mapping_properties_kwargs: (
-                dict[str, model_pb2.ShellMappingProperties]
-                | dict[str, model_pb2.SolidMappingProperties]
+                dict[str, hdf5_composite_cae_import_pb2.ShellMappingProperties]
+                | dict[str, hdf5_composite_cae_import_pb2.SolidMappingProperties]
             ) = {
-                "shell_mapping_properties": model_pb2.ShellMappingProperties(
+                "shell_mapping_properties": hdf5_composite_cae_import_pb2.ShellMappingProperties(
                     all_elements=shell_mapping_properties.all_elements,
                     element_sets=[
                         element_set._resource_path
@@ -581,7 +582,7 @@ class Model(TreeObject):
         else:
             assert projection_mode == HDF5CompositeCAEProjectionMode.SOLID
             mapping_properties_kwargs = {
-                "solid_mapping_properties": model_pb2.SolidMappingProperties(
+                "solid_mapping_properties": hdf5_composite_cae_import_pb2.SolidMappingProperties(
                     offset_type=offset_type_to_pb(solid_mapping_properties.offset_type)  # type: ignore
                 ),
             }
@@ -595,7 +596,7 @@ class Model(TreeObject):
                     projection_mode=hdf5_composite_cae_projection_mode_to_pb(projection_mode),  # type: ignore
                     minimum_angle_tolerance=minimum_angle_tolerance,
                     recompute_reference_directions=recompute_reference_directions,
-                    coordinate_transformation=model_pb2.CoordinateTransformation(
+                    coordinate_transformation=hdf5_composite_cae_import_pb2.CoordinateTransformation(
                         **dataclasses.asdict(coordinate_transformation)
                     ),
                     **mapping_properties_kwargs,

--- a/src/ansys/acp/core/_tree_objects/section_cut.py
+++ b/src/ansys/acp/core/_tree_objects/section_cut.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 import pathlib
 import typing
+import warnings
 
 from ansys.api.acp.v0 import section_cut_pb2, section_cut_pb2_grpc
 
@@ -97,17 +98,21 @@ class SectionCut(CreatableTreeObject, IdTreeObject):
     intersection_type :
         Determines the method used to compute a wire frame section cut. Used only
         if ``extrusion_type`` is ``ExtrusionType.WIRE_FRAME``.
-    use_default_tolerance :
+    use_default_minimum_segment_length :
         If True, the segment tolerance is computed as 0.1\% of the averaged element size.
         Otherwise, the ``tolerance`` value is used.
         Used only if ``extrusion_type`` is ``ExtrusionType.SURFACE_NORMAL`` or
         ``ExtrusionType.SURFACE_SWEEP_BASED``.
-    tolerance :
+    use_default_tolerance:
+        Deprecated alias for ``use_default_minimum_segment_length``.
+    minimum_segment_length  :
         Defines the minimum length of the segments. Segments shorter than this value
         are merged.
         Used only if ``extrusion_type`` is ``ExtrusionType.SURFACE_NORMAL`` or
-        ``ExtrusionType.SURFACE_SWEEP_BASED``, and ``use_default_tolerance`` is
+        ``ExtrusionType.SURFACE_SWEEP_BASED``, and ``use_default_minimum_segment_length`` is
         False.
+    tolerance :
+        Deprecated alias for ``minimum_segment_length``.
     use_default_interpolation_settings :
         If True, default interpolation settings are used by the sweep-based extrusion.
         Used only if ``extrusion_type`` is ``ExtrusionType.SURFACE_SWEEP_BASED``.
@@ -145,13 +150,52 @@ class SectionCut(CreatableTreeObject, IdTreeObject):
         core_scale_factor: float = 1.0,
         section_cut_type: SectionCutType = SectionCutType.MODELING_PLY_WISE,
         intersection_type: IntersectionType = IntersectionType.NORMAL_TO_SURFACE,
-        use_default_tolerance: bool = True,
-        tolerance: float = 0.0,
+        use_default_minimum_segment_length: bool | None = None,
+        minimum_segment_length: float | None = None,
+        use_default_tolerance: bool | None = None,
+        tolerance: float | None = None,
         use_default_interpolation_settings: bool = True,
         search_radius: float = 0.0,
         number_of_interpolation_points: int = 1,
     ) -> None:
         super().__init__(name=name)
+        if use_default_tolerance is not None:
+            if use_default_minimum_segment_length is not None:
+                raise ValueError(
+                    "Cannot specify both 'use_default_tolerance' and "
+                    "'use_default_minimum_segment_length'. Use only "
+                    "'use_default_minimum_segment_length'."
+                )
+            warnings.warn(
+                "The SectionCut property 'use_default_tolerance' is deprecated; use "
+                "the equivalent 'use_default_minimum_segment_length' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            use_default_minimum_segment_length = use_default_tolerance
+        if tolerance is not None:
+            if minimum_segment_length is not None:
+                raise ValueError(
+                    "Cannot specify both 'tolerance' and "
+                    "'minimum_segment_length'. Use only "
+                    "'minimum_segment_length'."
+                )
+            warnings.warn(
+                "The SectionCut property 'tolerance' is deprecated; use "
+                "the equivalent 'minimum_segment_length' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            minimum_segment_length = tolerance
+
+        # Defaults for minimum_segment_length and use_default_minimum_segment_length if not provided.
+        # We cannot set it as defaults in the function signature due to the check for the deprecated
+        # parameters above.
+        if use_default_minimum_segment_length is None:
+            use_default_minimum_segment_length = True
+        if minimum_segment_length is None:
+            minimum_segment_length = 0.0
+
         self.active = active
         self.origin = origin
         self.normal = normal
@@ -163,8 +207,8 @@ class SectionCut(CreatableTreeObject, IdTreeObject):
         self.core_scale_factor = core_scale_factor
         self.section_cut_type = section_cut_type
         self.intersection_type = intersection_type
-        self.use_default_tolerance = use_default_tolerance
-        self.tolerance = tolerance
+        self.use_default_minimum_segment_length = use_default_minimum_segment_length
+        self.minimum_segment_length = minimum_segment_length
         self.use_default_interpolation_settings = use_default_interpolation_settings
         self.search_radius = search_radius
         self.number_of_interpolation_points = number_of_interpolation_points
@@ -220,10 +264,32 @@ class SectionCut(CreatableTreeObject, IdTreeObject):
     )
 
     # surface properties - general
-    use_default_tolerance: ReadWriteProperty[bool, bool] = grpc_data_property(
-        "properties.use_default_tolerance"
+    use_default_minimum_segment_length: ReadWriteProperty[bool, bool] = grpc_data_property(
+        "properties.use_default_minimum_segment_length"
     )
-    tolerance: ReadWriteProperty[float, float] = grpc_data_property("properties.tolerance")
+    minimum_segment_length: ReadWriteProperty[float, float] = grpc_data_property(
+        "properties.minimum_segment_length"
+    )
+
+    use_default_tolerance: ReadWriteProperty[bool, bool] = grpc_data_property(
+        "properties.use_default_minimum_segment_length",
+        deprecated_msg=(
+            "The SectionCut parameter 'use_default_tolerance' is deprecated; use the equivalent "
+            "'use_default_minimum_segment_length' instead."
+        ),
+    )
+    tolerance: ReadWriteProperty[float, float] = grpc_data_property(
+        "properties.minimum_segment_length",
+        deprecated_msg=(
+            "The SectionCut parameter 'tolerance' is deprecated; use the equivalent "
+            "'minimum_segment_length' instead."
+        ),
+    )
+
+    minimum_thickness_to_length_ratio: ReadWriteProperty[float, float] = grpc_data_property(
+        "properties.minimum_thickness_to_length_ratio", readable_since="27.1", writable_since="27.1"
+    )
+
     # surface properties - sweep-based
     use_default_interpolation_settings: ReadWriteProperty[bool, bool] = grpc_data_property(
         "properties.use_default_interpolation_settings"

--- a/src/ansys/acp/core/_tree_objects/section_cut.py
+++ b/src/ansys/acp/core/_tree_objects/section_cut.py
@@ -113,6 +113,10 @@ class SectionCut(CreatableTreeObject, IdTreeObject):
         False.
     tolerance :
         Deprecated alias for ``minimum_segment_length``.
+    minimum_thickness_to_length_ratio :
+        Defines the minimum thickness to length ratio of the elements. Elements with a smaller
+        ratio are refined. Zero means that no refinement is applied. It's recommended to use a
+        value between 0 and 1.
     use_default_interpolation_settings :
         If True, default interpolation settings are used by the sweep-based extrusion.
         Used only if ``extrusion_type`` is ``ExtrusionType.SURFACE_SWEEP_BASED``.
@@ -152,6 +156,7 @@ class SectionCut(CreatableTreeObject, IdTreeObject):
         intersection_type: IntersectionType = IntersectionType.NORMAL_TO_SURFACE,
         use_default_minimum_segment_length: bool | None = None,
         minimum_segment_length: float | None = None,
+        minimum_thickness_to_length_ratio: float = 0.0,
         use_default_tolerance: bool | None = None,
         tolerance: float | None = None,
         use_default_interpolation_settings: bool = True,
@@ -209,6 +214,7 @@ class SectionCut(CreatableTreeObject, IdTreeObject):
         self.intersection_type = intersection_type
         self.use_default_minimum_segment_length = use_default_minimum_segment_length
         self.minimum_segment_length = minimum_segment_length
+        self.minimum_thickness_to_length_ratio = minimum_thickness_to_length_ratio
         self.use_default_interpolation_settings = use_default_interpolation_settings
         self.search_radius = search_radius
         self.number_of_interpolation_points = number_of_interpolation_points

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,7 +317,7 @@ def raises_before_version(acp_instance):
     @contextmanager
     def inner(version: str):
         if parse_version(acp_instance.server_version) < parse_version(version):
-            with pytest.raises(RuntimeError):
+            with pytest.raises((RuntimeError, ValueError)):
                 yield
         else:
             yield

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -288,17 +288,18 @@ def test_change_unit_system(minimal_complete_model, unit_system, raises_before_v
         "mmkms": 1.0,
     }
 
-    with raises_before_version("25.1"):
+    # The MMKMS unit system is not supported on servers prior to 27.1:
+    if unit_system == UnitSystemType.MMKMS:
+        supported_since = "27.1"
+    else:
+        supported_since = "25.1"
+
+    with raises_before_version(supported_since):
         if unit_system in (UnitSystemType.UNDEFINED, UnitSystemType.FROM_FILE):
             with pytest.raises(ValueError):
                 minimal_complete_model.unit_system = unit_system
         else:
-            # The MMKMS unit system is not supported on servers prior to 27.1:
-            if unit_system == UnitSystemType.MMKMS:
-                with raises_before_version("27.1"):
-                    minimal_complete_model.unit_system = unit_system
-            else:
-                minimal_complete_model.unit_system = unit_system
+            minimal_complete_model.unit_system = unit_system
             assert minimal_complete_model.unit_system == unit_system
             minimal_complete_model.update()
 

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -285,6 +285,7 @@ def test_change_unit_system(minimal_complete_model, unit_system, raises_before_v
         "bin": 0.03937008,
         "bft": 0.00328084,
         "umks": 1e3,
+        "mmkms": 1.0,
     }
 
     with raises_before_version("25.1"):
@@ -292,7 +293,12 @@ def test_change_unit_system(minimal_complete_model, unit_system, raises_before_v
             with pytest.raises(ValueError):
                 minimal_complete_model.unit_system = unit_system
         else:
-            minimal_complete_model.unit_system = unit_system
+            # The MMKMS unit system is not supported on servers prior to 27.1:
+            if unit_system == UnitSystemType.MMKMS:
+                with raises_before_version("27.1"):
+                    minimal_complete_model.unit_system = unit_system
+            else:
+                minimal_complete_model.unit_system = unit_system
             assert minimal_complete_model.unit_system == unit_system
             minimal_complete_model.update()
 

--- a/tests/unittests/test_section_cut.py
+++ b/tests/unittests/test_section_cut.py
@@ -56,8 +56,8 @@ class TestSectionCut(NoLockedMixin, TreeObjectTester):
 
     @staticmethod
     @pytest.fixture
-    def default_properties():
-        return {
+    def default_properties(acp_instance):
+        properties = {
             "status": "NOTUPTODATE",
             "locked": False,
             "active": True,
@@ -77,35 +77,42 @@ class TestSectionCut(NoLockedMixin, TreeObjectTester):
             "search_radius": 0.0,
             "number_of_interpolation_points": 1,
         }
+        if parse_version(acp_instance.server_version) >= parse_version("27.1"):
+            properties["minimum_thickness_to_length_ratio"] = 0.0
+        return properties
 
     @staticmethod
     @pytest.fixture
-    def object_properties(parent_object):
+    def object_properties(parent_object, acp_instance):
+        read_write = [
+            ("name", "new_name"),
+            ("active", False),
+            ("origin", (0.1, 0.2, 0.3)),
+            ("normal", (0, 1.0 / math.sqrt(2), 1.0 / math.sqrt(2))),
+            ("in_plane_reference_direction1", (math.sqrt(1 / 3), math.sqrt(2 / 3), 0)),
+            ("scope_entire_model", False),
+            (
+                "scope_element_sets",
+                [parent_object.create_element_set(), parent_object.create_element_set()],
+            ),
+            ("extrusion_type", ExtrusionType.SURFACE_NORMAL),
+            ("extrusion_type", ExtrusionType.SURFACE_SWEEP_BASED),
+            ("scale_factor", 1.5),
+            ("core_scale_factor", 12.3),
+            ("section_cut_type", SectionCutType.PRODUCTION_PLY_WISE),
+            ("section_cut_type", SectionCutType.ANALYSIS_PLY_WISE),
+            ("intersection_type", IntersectionType.IN_PLANE),
+            ("use_default_minimum_segment_length", False),
+            ("minimum_segment_length", 0.6),
+            ("use_default_interpolation_settings", False),
+            ("search_radius", 12.3),
+            ("number_of_interpolation_points", 5),
+        ]
+        if parse_version(acp_instance.server_version) >= parse_version("27.1"):
+            read_write.append(("minimum_thickness_to_length_ratio", 0.25))
+
         return ObjectPropertiesToTest(
-            read_write=[
-                ("name", "new_name"),
-                ("active", False),
-                ("origin", (0.1, 0.2, 0.3)),
-                ("normal", (0, 1.0 / math.sqrt(2), 1.0 / math.sqrt(2))),
-                ("in_plane_reference_direction1", (math.sqrt(1 / 3), math.sqrt(2 / 3), 0)),
-                ("scope_entire_model", False),
-                (
-                    "scope_element_sets",
-                    [parent_object.create_element_set(), parent_object.create_element_set()],
-                ),
-                ("extrusion_type", ExtrusionType.SURFACE_NORMAL),
-                ("extrusion_type", ExtrusionType.SURFACE_SWEEP_BASED),
-                ("scale_factor", 1.5),
-                ("core_scale_factor", 12.3),
-                ("section_cut_type", SectionCutType.PRODUCTION_PLY_WISE),
-                ("section_cut_type", SectionCutType.ANALYSIS_PLY_WISE),
-                ("intersection_type", IntersectionType.IN_PLANE),
-                ("use_default_minimum_segment_length", False),
-                ("minimum_segment_length", 0.6),
-                ("use_default_interpolation_settings", False),
-                ("search_radius", 12.3),
-                ("number_of_interpolation_points", 5),
-            ],
+            read_write=read_write,
             read_only=[
                 ("id", "some_id"),
                 ("status", "UPTODATE"),

--- a/tests/unittests/test_section_cut.py
+++ b/tests/unittests/test_section_cut.py
@@ -100,8 +100,8 @@ class TestSectionCut(NoLockedMixin, TreeObjectTester):
                 ("section_cut_type", SectionCutType.PRODUCTION_PLY_WISE),
                 ("section_cut_type", SectionCutType.ANALYSIS_PLY_WISE),
                 ("intersection_type", IntersectionType.IN_PLANE),
-                ("use_default_tolerance", False),
-                ("tolerance", 0.6),
+                ("use_default_minimum_segment_length", False),
+                ("minimum_segment_length", 0.6),
                 ("use_default_interpolation_settings", False),
                 ("search_radius", 12.3),
                 ("number_of_interpolation_points", 5),
@@ -112,6 +112,62 @@ class TestSectionCut(NoLockedMixin, TreeObjectTester):
                 ("locked", True),
             ],
         )
+
+
+@pytest.mark.parametrize(
+    "deprecated_property,value",
+    [
+        ("use_default_tolerance", False),
+        ("tolerance", 0.6),
+    ],
+)
+def test_section_cut_deprecated_property_set_warns(tree_object, deprecated_property, value):
+    with pytest.warns(DeprecationWarning, match=rf"'{deprecated_property}'.*deprecated"):
+        setattr(tree_object, deprecated_property, value)
+
+
+@pytest.mark.parametrize("deprecated_property", ["use_default_tolerance", "tolerance"])
+def test_section_cut_deprecated_property_get_warns(tree_object, deprecated_property):
+    with pytest.warns(DeprecationWarning, match=rf"'{deprecated_property}'.*deprecated"):
+        getattr(tree_object, deprecated_property)
+
+
+@pytest.mark.parametrize(
+    "deprecated_arg,replacement_arg,value",
+    [
+        (
+            "use_default_tolerance",
+            "use_default_minimum_segment_length",
+            False,
+        ),
+        ("tolerance", "minimum_segment_length", 0.6),
+    ],
+)
+def test_section_cut_constructor_deprecated_argument_warns(deprecated_arg, replacement_arg, value):
+    with pytest.warns(DeprecationWarning, match=rf"'{deprecated_arg}'.*deprecated"):
+        section_cut = SectionCut(**{deprecated_arg: value})
+
+    assert getattr(section_cut, replacement_arg) == value
+
+
+@pytest.mark.parametrize(
+    "deprecated_arg,replacement_arg,value",
+    [
+        (
+            "use_default_tolerance",
+            "use_default_minimum_segment_length",
+            False,
+        ),
+        ("tolerance", "minimum_segment_length", 0.6),
+    ],
+)
+def test_section_cut_create_method_deprecated_argument_warns(
+    parent_object, deprecated_arg, replacement_arg, value
+):
+    with pytest.warns(DeprecationWarning, match=rf"'{deprecated_arg}'.*deprecated"):
+        section_cut = parent_object.create_section_cut(**{deprecated_arg: value})
+
+    assert getattr(section_cut, replacement_arg) == value
 
 
 @pytest.mark.parametrize("export_type", ["mesh_only", "solid_model"])

--- a/uv.lock
+++ b/uv.lock
@@ -239,7 +239,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ansys-api-acp", specifier = "==0.3.1" },
+    { name = "ansys-api-acp", git = "https://github.com/ansys/ansys-api-acp.git?branch=feat%2Fupdate_protos" },
     { name = "ansys-dpf-composites", marker = "extra == 'all'", specifier = ">=0.6" },
     { name = "ansys-dpf-composites", marker = "extra == 'examples'", specifier = ">=0.6" },
     { name = "ansys-dpf-core", marker = "extra == 'all'", specifier = ">=0.13" },
@@ -292,15 +292,11 @@ test = [
 
 [[package]]
 name = "ansys-api-acp"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
+version = "0.4.0.dev0"
+source = { git = "https://github.com/ansys/ansys-api-acp.git?branch=feat%2Fupdate_protos#7e892deb9ff926db71f667269faa31551e0fa35f" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/c4/67dc7609d894686f77d0469c4ed496559d099356c6728068e2be22237681/ansys_api_acp-0.3.1.tar.gz", hash = "sha256:bcef570ac7de6f9817e5c179bb017a853f439e8f0695f884bc1a4e71cb0261f1", size = 164995, upload-time = "2025-08-07T13:47:08.993Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/17/ed7d50215fa0968dfbc10b231d6f1704163b1481d0ae75401b5fd5c79b55/ansys_api_acp-0.3.1-py3-none-any.whl", hash = "sha256:6ecd0939c31d08df95723207c2fa748561ce5a873c41f2b7bde0b897803cdb65", size = 350951, upload-time = "2025-08-07T13:47:07.221Z" },
 ]
 
 [[package]]
@@ -3806,7 +3802,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -3881,7 +3877,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4007,23 +4003,23 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.12'" },
-    { name = "babel", marker = "python_full_version < '3.12'" },
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.12'" },
-    { name = "imagesize", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -4039,23 +4035,23 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,7 @@ requires-dist = [
     { name = "ansys-mechanical-core", marker = "extra == 'examples'", specifier = ">=0.10.0" },
     { name = "ansys-tools-common", specifier = ">=0.4.0" },
     { name = "ansys-tools-filetransfer", specifier = ">=0.2.1" },
-    { name = "grpcio-health-checking", specifier = ">=1.43" },
+    { name = "grpcio-health-checking", specifier = ">=1.71" },
     { name = "matplotlib", marker = "extra == 'all'", specifier = ">=3.8.3" },
     { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.8.3" },
     { name = "networkx", specifier = ">=3.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -239,7 +239,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ansys-api-acp", git = "https://github.com/ansys/ansys-api-acp.git?branch=feat%2Fupdate_protos" },
+    { name = "ansys-api-acp", specifier = "==0.4.0" },
     { name = "ansys-dpf-composites", marker = "extra == 'all'", specifier = ">=0.6" },
     { name = "ansys-dpf-composites", marker = "extra == 'examples'", specifier = ">=0.6" },
     { name = "ansys-dpf-core", marker = "extra == 'all'", specifier = ">=0.13" },
@@ -292,11 +292,15 @@ test = [
 
 [[package]]
 name = "ansys-api-acp"
-version = "0.4.0.dev0"
-source = { git = "https://github.com/ansys/ansys-api-acp.git?branch=feat%2Fupdate_protos#7e892deb9ff926db71f667269faa31551e0fa35f" }
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/a0/0c4dd9c1c1aaa8cb87e45d6ac7f9e725ceb7bbd0ac0e2ffc020c969bb9e8/ansys_api_acp-0.4.0.tar.gz", hash = "sha256:64426ce9a0fde5dd9b61eca41af7dc605ac6367e3ed6842993582256e00a63ef", size = 227559, upload-time = "2026-07-06T12:17:32.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/79/643513cd581241da1b4b73c0e91015c895bc3035d59fbdafcc61f419721a/ansys_api_acp-0.4.0-py3-none-any.whl", hash = "sha256:7913e3de8d676aad55a23655e685355989911b470f8fb3313288b041dfc0ae3c", size = 481276, upload-time = "2026-07-06T12:17:31.283Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -239,7 +239,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ansys-api-acp", specifier = "==0.4.0" },
+    { name = "ansys-api-acp", specifier = "==0.4.1" },
     { name = "ansys-dpf-composites", marker = "extra == 'all'", specifier = ">=0.6" },
     { name = "ansys-dpf-composites", marker = "extra == 'examples'", specifier = ">=0.6" },
     { name = "ansys-dpf-core", marker = "extra == 'all'", specifier = ">=0.13" },
@@ -292,15 +292,15 @@ test = [
 
 [[package]]
 name = "ansys-api-acp"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/a0/0c4dd9c1c1aaa8cb87e45d6ac7f9e725ceb7bbd0ac0e2ffc020c969bb9e8/ansys_api_acp-0.4.0.tar.gz", hash = "sha256:64426ce9a0fde5dd9b61eca41af7dc605ac6367e3ed6842993582256e00a63ef", size = 227559, upload-time = "2026-07-06T12:17:32.945Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/56/2b84561d7bd8cade38d3c7f142c979b03a0351f81082ca260aad849220bf/ansys_api_acp-0.4.1.tar.gz", hash = "sha256:121524bf2db03a20b87b093b28f36f99c17ca05765f29baad6b8407b699bbb2d", size = 227503, upload-time = "2026-07-09T20:11:59.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/79/643513cd581241da1b4b73c0e91015c895bc3035d59fbdafcc61f419721a/ansys_api_acp-0.4.0-py3-none-any.whl", hash = "sha256:7913e3de8d676aad55a23655e685355989911b470f8fb3313288b041dfc0ae3c", size = 481276, upload-time = "2026-07-06T12:17:31.283Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/1d/e8668b792b53a1f4b6070437e302dad61add2ab729d481f6899d8ac61da2/ansys_api_acp-0.4.1-py3-none-any.whl", hash = "sha256:781fe20fbfe029a0969df45d8093d7c454acafe12d0f8a75f4993b071398205e", size = 481320, upload-time = "2026-07-09T20:11:58.05Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump API package to `0.4.1` and adapt to its changes:
- Some messages moved from `model_pb2` to `hdf5_composite_cae_import_pb2`.
- Section cut properties `use_default_tolerance` and `tolerance` renamed to `use_default_minimum_segment_length` and `minimum_segment_length`. Using the old names still works, but emits a deprecation warning.
- Added `MMKMS` unit system, which only works from server version 27.1.
- Add support for the SectionCut `minimum_thickness_to_length_ratio` property.