### PR TITLE
Fix benchmark store permissions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -264,16 +264,41 @@ jobs:
           IMAGE_NAME: ghcr.io/ansys/acp:${{ matrix.server-version }}
           RUN_FULL_BENCHMARKS: ${{ matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.server-version == 'latest' }}
 
+      - name: Upload benchmark result artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-output
+          path: tests/benchmarks/benchmark_output.json
+          retention-days: 7
+        if: matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.server-version == 'latest'
+
+  benchmark-publish:
+    name: Publish benchmark to gh-pages
+    runs-on: ubuntu-latest
+    needs: [testing]
+    permissions:
+      contents: write # needs to write to the gh-pages branch
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download benchmark result artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: benchmark-output
+          path: benchmark-output
+
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           name: 'PyACP benchmarks'
           tool: 'pytest'
-          output-file-path: tests/benchmarks/benchmark_output.json
+          output-file-path: benchmark-output/benchmark_output.json
           benchmark-data-dir-path: benchmarks
           auto-push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        if: matrix.python-version == env.MAIN_PYTHON_VERSION && matrix.server-version == 'latest' && github.ref == 'refs/heads/main'
 
   doctest:
     name: Test documentation snippets


### PR DESCRIPTION
Add a separate job to publish the benchmark results.

Give `contents: write` permission to this job so that it can write to the `gh-pages` branch.