### PR TITLE
Add an `access_path` property to tree objects

### DIFF
--- a/src/ansys/acp/core/_server/acp_instance.py
+++ b/src/ansys/acp/core/_server/acp_instance.py
@@ -305,7 +305,7 @@ class ACPInstance(Generic[ServerT]):
     def models(self) -> tuple[Model, ...]:
         """Models currently loaded on the server.
 
-        Note that the models are listed in arbitrary order.
+        Note that models are listed in an arbitrary but deterministic (per session) order.
         """
         from .._tree_objects import Model
         from .._tree_objects.base import ServerWrapper

--- a/src/ansys/acp/core/_tree_objects/base.py
+++ b/src/ansys/acp/core/_tree_objects/base.py
@@ -35,7 +35,13 @@ from grpc import Channel
 from packaging.version import Version
 from packaging.version import parse as parse_version
 
-from ansys.api.acp.v0.base_pb2 import CollectionPath, DeleteRequest, GetRequest, ResourcePath
+from ansys.api.acp.v0.base_pb2 import (
+    CollectionPath,
+    DeleteRequest,
+    GetRequest,
+    ListRequest,
+    ResourcePath,
+)
 
 from .._server.acp_instance import ACPInstance, FileTransferHandler
 from .._utils.path_to_str import path_to_str_checked
@@ -175,6 +181,54 @@ class TreeObjectBase(ObjectCacheMixin, GrpcObjectBase):
         if parent is None:
             raise RuntimeError("The parent object could not be found.")
         return parent
+
+    @property
+    def access_path(self) -> str:
+        """Python expression suffix for accessing this object from an ACP instance.
+
+        When appended to an ACP instance variable, this expression evaluates to the object.
+        """
+        # The collection name used in PyACP is not inherently tied to the API.
+        # This mapping tracks cases where the two differ.
+        collection_name_mapping = {
+            "cad_components": "root_shapes",
+            "lookup_table_1d_columns": "columns",
+            "lookup_table_3d_columns": "columns",
+            "cutoff_selection_rules": "cut_off_selection_rules",
+        }
+        collection_label = collection_name_mapping.get(
+            self._COLLECTION_LABEL, self._COLLECTION_LABEL
+        )
+
+        if not self._is_stored:
+            raise RuntimeError("Cannot get the access string of an unstored object.")
+
+        from .model import Model
+
+        if not isinstance(self, Model):
+            if not isinstance(self, IdTreeObject):
+                raise RuntimeError(
+                    f"The '{type(self).__name__}' object does not have an identifier."
+                )
+            parent = self.parent
+            if not isinstance(parent, TreeObjectBase):
+                raise RuntimeError("The parent object is not a tree object.")
+            return f"{parent.access_path}.{collection_label}[{self.id!r}]"
+
+        from ansys.api.acp.v0 import model_pb2_grpc
+
+        model_stub = model_pb2_grpc.ObjectServiceStub(self._channel)
+        with wrap_grpc_errors():
+            model_infos = sorted(
+                model_stub.List(
+                    ListRequest(collection_path=CollectionPath(value=Model._COLLECTION_LABEL))
+                ).objects,
+                key=lambda model_info: model_info.info.resource_path.value,
+            )
+        for model_index, model_info in enumerate(model_infos):
+            if model_info.info.resource_path == self._resource_path:
+                return f".models[{model_index}]"
+        raise RuntimeError("The model could not be found.")
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__} with name '{self.name}'>"

--- a/tests/unittests/common/tree_object_tester.py
+++ b/tests/unittests/common/tree_object_tester.py
@@ -127,6 +127,13 @@ class TreeObjectTesterReadOnly:
 
         assert object_collection[ref_id].parent is parent_object
 
+    @staticmethod
+    def test_access_path_eval(acp_instance, collection_test_data):
+        """Test the ACP instance access string of the objects in the collection."""
+        object_collection, _, object_ids = collection_test_data
+        tree_object = object_collection[object_ids[0]]
+        assert eval(f"acp_instance{tree_object.access_path}") is tree_object
+
 
 class TreeObjectTester(TreeObjectTesterReadOnly):
     COLLECTION_NAME: str
@@ -234,6 +241,14 @@ class TreeObjectTester(TreeObjectTesterReadOnly):
             object.parent
         assert "unstored" in str(exc.value)
         assert "parent" in str(exc.value)
+
+    @staticmethod
+    def test_unstored_access_path_raises(tree_object):
+        """Test that unstored objects raise an error when accessing the access string."""
+        with pytest.raises(RuntimeError) as exc:
+            tree_object.clone().access_path
+        assert "unstored" in str(exc.value)
+        assert "access string" in str(exc.value)
 
 
 class NoLockedMixin(TreeObjectTester):

--- a/tests/unittests/test_model.py
+++ b/tests/unittests/test_model.py
@@ -119,6 +119,25 @@ def test_string_representation(acp_instance, model_data_dir):
     assert f"name='{model.name}'" in model_str
 
 
+def test_access_path(acp_instance, model_data_dir):
+    first_model = acp_instance.import_model(
+        path=model_data_dir / "ACP-Pre.h5",
+        format="ansys:h5",
+    )
+    second_model = acp_instance.import_model(
+        path=model_data_dir / "ACP-Pre.h5",
+        format="ansys:h5",
+    )
+    third_model = acp_instance.import_model(
+        path=model_data_dir / "ACP-Pre.h5",
+        format="ansys:h5",
+    )
+
+    assert eval(f"acp_instance{first_model.access_path}") is first_model
+    assert eval(f"acp_instance{second_model.access_path}") is second_model
+    assert eval(f"acp_instance{third_model.access_path}") is third_model
+
+
 @pytest.fixture
 def minimal_complete_model(load_model_from_tempfile):
     with load_model_from_tempfile() as model:


### PR DESCRIPTION
Add a property `access_path` to the tree objects, which returns a string representing how the object can be accessed from the `ACPInstance` object.

For example, a ModelingPly might have an `access_path` of ``.models[1].modeling_groups['hull'].modeling_plies['core']`` if
- 1 is the index of the model in the models collection
- 'hull' is the ModelingGroup ID
- 'core' is the ModelingPly ID

This is similar to the `root_path` property in the ACP GUI Python scripting.